### PR TITLE
Add preference for max lines per entry in timeline

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -76,7 +76,7 @@ dependencies {
     implementation "androidx.navigation:navigation-fragment-ktx:2.2.2"
     implementation "androidx.navigation:navigation-ui-ktx:2.2.2"
     implementation 'androidx.core:core-ktx:1.3.0'
-    implementation 'androidx.preference:preference:1.0.0'
+    implementation 'androidx.preference:preference:1.1.1'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:2.3.0-alpha04"

--- a/app/src/main/java/journal/gratitude/com/gratitudejournal/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/journal/gratitude/com/gratitudejournal/ui/settings/SettingsFragment.kt
@@ -9,6 +9,9 @@ import android.content.SharedPreferences
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Bundle
+import android.text.InputFilter
+import android.text.InputType
+import android.text.Spanned
 import android.view.View
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
@@ -20,6 +23,7 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
+import androidx.preference.EditTextPreference
 import androidx.preference.ListPreference
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
@@ -73,40 +77,40 @@ class SettingsFragment : PreferenceFragmentCompat(),
 
         setPreferencesFromResource(R.xml.preferences, rootKey)
 
-        val privacy = findPreference("privacy_policy")
-        privacy.setOnPreferenceClickListener {
+        val privacy = findPreference<Preference>("privacy_policy")
+        privacy?.setOnPreferenceClickListener {
             openPrivacyPolicy()
             true
         }
-        val terms = findPreference("terms_conditions")
-        terms.setOnPreferenceClickListener {
+        val terms = findPreference<Preference>("terms_conditions")
+        terms?.setOnPreferenceClickListener {
             openTermsAndConditions()
             true
         }
-        val faq = findPreference("faq")
-        faq.setOnPreferenceClickListener {
+        val faq = findPreference<Preference>("faq")
+        faq?.setOnPreferenceClickListener {
             openFaq()
             true
         }
-        val theme = findPreference(THEME_PREF)
-        theme.setOnPreferenceClickListener {
+        val theme = findPreference<Preference>(THEME_PREF)
+        theme?.setOnPreferenceClickListener {
             openThemes()
             true
         }
-        val oss = findPreference("open_source")
-        oss.setOnPreferenceClickListener {
+        val oss = findPreference<Preference>("open_source")
+        oss?.setOnPreferenceClickListener {
             startActivity(Intent(context, OssLicensesMenuActivity::class.java))
             true
         }
 
-        val version = findPreference(VERSION_PREF)
+        val version = findPreference<Preference>(VERSION_PREF)
         val versionNum = BuildConfig.VERSION_NAME
-        version.summary = versionNum
-        val dropbox = findPreference(BACKUP_TOKEN)
-        val cadencePref = (findPreference(BACKUP_CADENCE) as ListPreference)
+        version?.summary = versionNum
+        val dropbox = findPreference<Preference>(BACKUP_TOKEN)
+        val cadencePref = (findPreference<Preference>(BACKUP_CADENCE) as ListPreference)
 
 
-        dropbox.setOnPreferenceClickListener {
+        dropbox?.setOnPreferenceClickListener {
             val wantsToLogin = preferenceScreen.sharedPreferences.getBoolean(BACKUP_TOKEN, false)
             if (!wantsToLogin) {
                 firebaseAnalytics.logEvent(DROPBOX_DEAUTH, null)
@@ -129,23 +133,22 @@ class SettingsFragment : PreferenceFragmentCompat(),
         }
         cadencePref.setValueIndex(index)
 
-        val oneTimeExport = findPreference(ONE_TIME_EXPORT_PREF)
-        oneTimeExport.setOnPreferenceClickListener {
+        val oneTimeExport = findPreference<Preference>(ONE_TIME_EXPORT_PREF)
+        oneTimeExport?.setOnPreferenceClickListener {
             exportToCsv()
             true
         }
 
-        val import = findPreference(IMPORT_PREF)
-        import.setOnPreferenceClickListener {
+        val import = findPreference<Preference>(IMPORT_PREF)
+        import?.setOnPreferenceClickListener {
             importFromCsv()
             true
         }
 
-        val fingerprint = findPreference(FINGERPRINT)
+        val fingerprint = findPreference<Preference>(FINGERPRINT)
         val canAuthenticateUsingFingerPrint =
             BiometricManager.from(requireContext()).canAuthenticate() == BiometricManager.BIOMETRIC_SUCCESS
-        fingerprint.parent!!.isEnabled = canAuthenticateUsingFingerPrint
-
+        fingerprint?.parent!!.isEnabled = canAuthenticateUsingFingerPrint
     }
 
     override fun onResume() {
@@ -514,5 +517,6 @@ class SettingsFragment : PreferenceFragmentCompat(),
         const val ONE_TIME_EXPORT_PREF = "one_time_export"
         const val IMPORT_PREF = "import_entries"
         const val DAY_OF_WEEK = "day_of_week"
+        const val LINES_PER_ENTRY_IN_TIMELINE = "lines_per_entry_in_timeline"
     }
 }

--- a/app/src/main/java/journal/gratitude/com/gratitudejournal/ui/timeline/TimelineAdapter.kt
+++ b/app/src/main/java/journal/gratitude/com/gratitudejournal/ui/timeline/TimelineAdapter.kt
@@ -7,14 +7,19 @@ import journal.gratitude.com.gratitudejournal.model.TimelineItem
 import journal.gratitude.com.gratitudejournal.ui.bindingadapter.BindableAdapter
 import org.threeten.bp.LocalDate
 
-class TimelineAdapter(activity: Activity, showDayOfWeek: Boolean, onClickListener: OnClickListener) : androidx.recyclerview.widget.RecyclerView.Adapter<androidx.recyclerview.widget.RecyclerView.ViewHolder>(), BindableAdapter<List<TimelineItem>> {
+class TimelineAdapter(
+    activity: Activity,
+    showDayOfWeek: Boolean,
+    linesPerEntry: Int,
+    onClickListener: OnClickListener
+) : androidx.recyclerview.widget.RecyclerView.Adapter<androidx.recyclerview.widget.RecyclerView.ViewHolder>(), BindableAdapter<List<TimelineItem>> {
 
     private lateinit var entries: List<TimelineItem>
 
     private val delegatesManager = AdapterDelegatesManager<List<TimelineItem>>()
 
     init {
-        delegatesManager.addDelegate(TimelineEntryAdapterDelegate(activity, showDayOfWeek, onClickListener))
+        delegatesManager.addDelegate(TimelineEntryAdapterDelegate(activity, showDayOfWeek, linesPerEntry, onClickListener))
         delegatesManager.addDelegate(TimelineMilstoneAdapterDelegate(activity))
     }
 

--- a/app/src/main/java/journal/gratitude/com/gratitudejournal/ui/timeline/TimelineEntryAdapterDelegate.kt
+++ b/app/src/main/java/journal/gratitude/com/gratitudejournal/ui/timeline/TimelineEntryAdapterDelegate.kt
@@ -11,7 +11,12 @@ import journal.gratitude.com.gratitudejournal.R
 import journal.gratitude.com.gratitudejournal.model.Entry
 import journal.gratitude.com.gratitudejournal.model.TimelineItem
 
-class TimelineEntryAdapterDelegate(activity: Activity, val showDayOfWeek: Boolean, private val clickListener: TimelineAdapter.OnClickListener) : AdapterDelegate<List<TimelineItem>>() {
+class TimelineEntryAdapterDelegate(
+    activity: Activity,
+    val showDayOfWeek: Boolean,
+    val linesPerEntry: Int,
+    private val clickListener: TimelineAdapter.OnClickListener
+) : AdapterDelegate<List<TimelineItem>>() {
 
     private val inflater = activity.layoutInflater
 
@@ -41,7 +46,17 @@ class TimelineEntryAdapterDelegate(activity: Activity, val showDayOfWeek: Boolea
     inner class TimelineEntryViewHolder(private val binding: ViewDataBinding) : RecyclerView.ViewHolder(binding.root) {
 
         fun bind(timelineEntry: Entry, isLastItem: Boolean, numEntries: Int) {
-            binding.setVariable(BR.entryViewModel, TimelineEntryViewModel(timelineEntry, isLastItem, numEntries, showDayOfWeek, clickListener))
+            binding.setVariable(
+                BR.entryViewModel,
+                TimelineEntryViewModel(
+                    timelineEntry,
+                    isLastItem,
+                    numEntries,
+                    showDayOfWeek,
+                    linesPerEntry,
+                    clickListener
+                )
+            )
             binding.executePendingBindings()
         }
     }

--- a/app/src/main/java/journal/gratitude/com/gratitudejournal/ui/timeline/TimelineEntryViewModel.kt
+++ b/app/src/main/java/journal/gratitude/com/gratitudejournal/ui/timeline/TimelineEntryViewModel.kt
@@ -14,6 +14,7 @@ class TimelineEntryViewModel(
         private val isLastItem: Boolean,
         private val numEntries: Int,
         private val showDayOfWeek: Boolean,
+        val maxLines: Int,
         private val clickListener: TimelineAdapter.OnClickListener
 ) {
 

--- a/app/src/main/java/journal/gratitude/com/gratitudejournal/ui/timeline/TimelineFragment.kt
+++ b/app/src/main/java/journal/gratitude/com/gratitudejournal/ui/timeline/TimelineFragment.kt
@@ -32,6 +32,7 @@ import journal.gratitude.com.gratitudejournal.ui.entry.EntryFragment.Companion.D
 import journal.gratitude.com.gratitudejournal.ui.entry.EntryFragment.Companion.IS_NEW_ENTRY
 import journal.gratitude.com.gratitudejournal.ui.entry.EntryFragment.Companion.NUM_ENTRIES
 import journal.gratitude.com.gratitudejournal.ui.settings.SettingsFragment.Companion.DAY_OF_WEEK
+import journal.gratitude.com.gratitudejournal.ui.settings.SettingsFragment.Companion.LINES_PER_ENTRY_IN_TIMELINE
 import journal.gratitude.com.gratitudejournal.util.backups.ExportCallback
 import journal.gratitude.com.gratitudejournal.util.toLocalDate
 import kotlinx.android.synthetic.main.timeline_fragment.*
@@ -97,7 +98,8 @@ class TimelineFragment : DaggerFragment() {
             androidx.recyclerview.widget.LinearLayoutManager(context)
         val sharedPrefs = PreferenceManager.getDefaultSharedPreferences(context)
         val showDayOfWeek = sharedPrefs?.getBoolean(DAY_OF_WEEK, false) ?: false
-        adapter = TimelineAdapter(activity!!, showDayOfWeek, object : TimelineAdapter.OnClickListener {
+        val linesPerEntry = sharedPrefs?.getInt(LINES_PER_ENTRY_IN_TIMELINE, 10) ?: 10
+        adapter = TimelineAdapter(activity!!, showDayOfWeek, linesPerEntry, object : TimelineAdapter.OnClickListener {
             override fun onClick(
                 clickedDate: LocalDate,
                 isNewEntry: Boolean,

--- a/app/src/main/res/layout/item_timeline_entry.xml
+++ b/app/src/main/res/layout/item_timeline_entry.xml
@@ -70,7 +70,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
             android:ellipsize="end"
-            android:maxLines="10"
+            android:maxLines="@{entryViewModel.maxLines}"
             android:minLines="3"
             android:text="@{entryViewModel.content}"
             android:textAlignment="viewStart"

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -82,6 +82,6 @@
     <string name="day_of_week_off">Das Datum enthält nicht den Wochentag</string>
     <string name="day_of_week_on">Datum beinhaltet Wochentag</string>
     <string name="day_of_week_title">Datumsstil</string>
-    <string name="max_lines_title">Max. Textzeilen in Zeitstrahl</string>
-    <string name="max_lines_summary">Wenn ein Eintrag diese Anzahl an Zeilen übersteigt, wird er abgekürzt dargestellt. Sie können auf den Eintrag tippen, um den vollständigen Text zu sehen.</string>
+    <string name="max_lines_title">Textzeilen in Zeitstrahl</string>
+    <string name="max_lines_summary">Anzahl der Textzeilen, die im Zeitstrahl angezeigt werden. Sie können den vollständigen Text zu sehen, indem Sie auf den Eintrag tippen.</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -82,4 +82,6 @@
     <string name="day_of_week_off">Das Datum enthält nicht den Wochentag</string>
     <string name="day_of_week_on">Datum beinhaltet Wochentag</string>
     <string name="day_of_week_title">Datumsstil</string>
+    <string name="max_lines_title">Max. Textzeilen in Zeitstrahl</string>
+    <string name="max_lines_summary">Wenn ein Eintrag diese Anzahl an Zeilen übersteigt, wird er abgekürzt dargestellt. Sie können auf den Eintrag tippen, um den vollständigen Text zu sehen.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -85,4 +85,6 @@
     <string name="day_of_week_off">Date does not include day of the week</string>
     <string name="day_of_week_on">Date includes day of the week</string>
     <string name="day_of_week_title">Date Style</string>
+    <string name="max_lines_title">Maximum Text Lines in Timeline</string>
+    <string name="max_lines_summary">If an entry exceeds this many lines, it will be truncated. You can press the entry to view the complete text.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -85,6 +85,6 @@
     <string name="day_of_week_off">Date does not include day of the week</string>
     <string name="day_of_week_on">Date includes day of the week</string>
     <string name="day_of_week_title">Date Style</string>
-    <string name="max_lines_title">Maximum Text Lines in Timeline</string>
-    <string name="max_lines_summary">If an entry exceeds this many lines, it will be truncated. You can press the entry to view the complete text.</string>
+    <string name="max_lines_title">Timeline Entry Length</string>
+    <string name="max_lines_summary">Number of lines shown in the timeline. The full text is visible when you click the entry.</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -46,7 +46,7 @@
         <SeekBarPreference
             android:defaultValue="10"
             android:key="lines_per_entry_in_timeline"
-            android:max="100"
+            android:max="50"
             android:summary="@string/max_lines_summary"
             android:title="@string/max_lines_title"
             app:min="1"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <PreferenceCategory
         android:layout="@layout/preference_category_view"
@@ -42,6 +43,14 @@
             android:summaryOn="@string/day_of_week_on"
             android:title="@string/day_of_week_title" />
 
+        <SeekBarPreference
+            android:defaultValue="10"
+            android:key="lines_per_entry_in_timeline"
+            android:max="100"
+            android:summary="@string/max_lines_summary"
+            android:title="@string/max_lines_title"
+            app:min="1"
+            app:showSeekBarValue="true" />
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/app/src/test/java/journal/gratitude/com/gratitudejournal/ui/timeline/TimelineEntryViewModelTest.kt
+++ b/app/src/test/java/journal/gratitude/com/gratitudejournal/ui/timeline/TimelineEntryViewModelTest.kt
@@ -22,6 +22,7 @@ class TimelineEntryViewModelTest {
         false,
         numEntries,
         false,
+        10,
         onClickListener
     )
 
@@ -39,6 +40,7 @@ class TimelineEntryViewModelTest {
             false,
             numEntries,
             false,
+            10,
             onClickListener
         )
         viewModel.onClick(mock())
@@ -54,6 +56,7 @@ class TimelineEntryViewModelTest {
             false,
             numEntries,
             false,
+            10,
             onClickListener
         )
 
@@ -71,6 +74,7 @@ class TimelineEntryViewModelTest {
             false,
             numEntries,
             false,
+            10,
             onClickListener
         )
 
@@ -88,6 +92,7 @@ class TimelineEntryViewModelTest {
             false,
             numEntries,
             false,
+            10,
             onClickListener
         )
 
@@ -113,6 +118,7 @@ class TimelineEntryViewModelTest {
             false,
             numEntries,
             false,
+            10,
             onClickListener
         )
 
@@ -146,6 +152,7 @@ class TimelineEntryViewModelTest {
             true,
             numEntries,
             false,
+            10,
             onClickListener
         )
 
@@ -177,6 +184,7 @@ class TimelineEntryViewModelTest {
             false,
             numEntries,
             true,
+            10,
             onClickListener
         )
 


### PR DESCRIPTION
Closes #110

I thought instead of disabling truncation altogether, maybe make the number of lines configurable. After all, having a whole essay in in the timeline would be bad UX.

![grafik](https://user-images.githubusercontent.com/1191816/89213552-8bdcd300-d5c5-11ea-9338-df4772be7c58.png)

![grafik](https://user-images.githubusercontent.com/1191816/89213564-9008f080-d5c5-11ea-8dcd-9018c4165b0f.png)
