### PR TITLE
Fix calendar height issue

### DIFF
--- a/app/src/main/res/layout/calendar_fragment.xml
+++ b/app/src/main/res/layout/calendar_fragment.xml
@@ -55,7 +55,7 @@
             <com.github.sundeepk.compactcalendarview.CompactCalendarView
                 android:id="@+id/compactcalendar_view"
                 android:layout_width="match_parent"
-                android:layout_height="200dp"
+                android:layout_height="260dp"
                 android:layout_marginTop="8dp"
                 android:elevation="6dp"
                 app:compactCalendarBackgroundColor="?attr/toolbarColor"
@@ -85,10 +85,9 @@
                 android:padding="12dp"
                 android:text="@string/random"
                 android:textColor="?attr/toolbarItemColor"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/compactcalendar_view"
-                tools:visibility="gone" />
+                app:layout_constraintBottom_toBottomOf="@id/compactcalendar_view"
+                app:layout_constraintEnd_toEndOf="@id/compactcalendar_view"
+                tools:visibility="visible" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 


### PR DESCRIPTION
## :scroll: Description
November 30, 2020 was unaccessible from the calendar. This fixes the issue! Fixes #155 

## :green_heart: How did you test it?
Manual testing

## :camera_flash: Screenshots / GIFs
<img width="323" alt="Screen Shot 2020-12-02 at 5 46 40 PM" src="https://user-images.githubusercontent.com/10744793/100952977-6655cc80-34c6-11eb-97cd-e1f7fbde1ec7.png">
