### PR TITLE
Add Screenshot Tests and a Screenshotbot Integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,8 @@ jobs:
       - *decrypt_gcloud_key
       - run:
           name: Set Google Cloud target project
-          command: true  # gcloud config set project gratitude-journal-app
+          command: true
+          # gcloud config set project gratitude-journal-app
       - run:
           name: Authenticate with Google Cloud
           command: gcloud auth activate-service-account presently-cicd-service-account@gratitude-journal-app.iam.gserviceaccount.com --key-file ${HOME}/client-secret.json

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,7 @@ jobs:
           command: gcloud auth activate-service-account presently-cicd-service-account@gratitude-journal-app.iam.gserviceaccount.com --key-file ${HOME}/client-secret.json
       - run:
           name: Run instrumented test on Firebase Test Lab
-          command: gcloud firebase test android run --type instrumentation --app app/build/outputs/apk/debug/app-debug.apk --test app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk --device model=walleye,version=27,locale=en_US,orientation=portrait --environment-variables coverage=true,coverageFile=/sdcard/coverage.ec --directories-to-pull=/sdcard --timeout 20m --directories-to-pull /sdcard/screenshots/journal.gratitude.com.gratitudejournal.test --results-bucket cloud-test-screenshotbot-example
+          command: gcloud firebase test android run --type instrumentation --app app/build/outputs/apk/debug/app-debug.apk --test app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk --device model=walleye,version=27,locale=en_US,orientation=portrait --environment-variables coverage=true,coverageFile=/sdcard/coverage.ec --directories-to-pull=/sdcard --timeout 20m
       - run:
           name: Create directory to store test results
           command: mkdir firebase
@@ -122,9 +122,9 @@ jobs:
           command: |
             curl https://screenshotbot.io/recorder.sh | sh
             cd ~/src && ~/screenshotbot/recorder \
-              --directory /root/src/firebase/*/artifacts/screenshot_bundle.zip \
+              --directory /root/src/firebase/*/artifacts/sdcard/screenshots/journal.gratitude.com.gratitudejournal.test/screenshots-default/screenshot_bundle.zip \
               --channel Presently \
-              --metadata /root/src/firebase/*/artifacts/metadata.xml \
+              --metadata /root/src/firebase/*/artifacts/sdcard/screenshots/journal.gratitude.com.gratitudejournal.test/screenshots-default/metadata.xml \
               --production \
               --branch ${CIRCLE_BRANCH} \
               --api-key ${SCREENSHOTBOT_API_KEY} \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,9 +122,9 @@ jobs:
           command: |
             curl https://screenshotbot.io/recorder.sh | sh
             cd ~/src && ~/screenshotbot/recorder \
-              --directory /root/src/firebase/*/*/artifacts/screenshot_bundle.zip \
+              --directory /root/src/firebase/*/artifacts/screenshot_bundle.zip \
               --channel Presently \
-              --metadata /root/src/firebase/*/*/artifacts/metadata.xml \
+              --metadata /root/src/firebase/*/artifacts/metadata.xml \
               --production \
               --branch ${CIRCLE_BRANCH} \
               --api-key ${SCREENSHOTBOT_API_KEY} \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,10 +101,9 @@ jobs:
     steps:
       - *attach_debug_workspace
       - *decrypt_gcloud_key
-      - run:
-          name: Set Google Cloud target project
-          command: true
-          # gcloud config set project gratitude-journal-app
+      # - run:
+      #     name: Set Google Cloud target project
+      #     command: gcloud config set project gratitude-journal-app
       - run:
           name: Authenticate with Google Cloud
           command: gcloud auth activate-service-account presently-cicd-service-account@gratitude-journal-app.iam.gserviceaccount.com --key-file ${HOME}/client-secret.json

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,6 +99,7 @@ jobs:
   test_instrumented:
     <<: *gcloud_config
     steps:
+      - checkout
       - *attach_debug_workspace
       - *decrypt_gcloud_key
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,6 +127,7 @@ jobs:
               --metadata /root/src/firebase/*/artifacts/sdcard/screenshots/journal.gratitude.com.gratitudejournal.test/screenshots-default/metadata.xml \
               --production \
               --branch ${CIRCLE_BRANCH} \
+              --main-branch develop \
               --api-key ${SCREENSHOTBOT_API_KEY} \
               --repo-url ${CIRCLE_REPOSITORY_URL} \
               --api-secret ${SCREENSHOTBOT_API_SECRET}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,6 +112,9 @@ jobs:
           name: Run instrumented test on Firebase Test Lab
           command: gcloud firebase test android run --type instrumentation --app app/build/outputs/apk/debug/app-debug.apk --test app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk --device model=walleye,version=27,locale=en_US,orientation=portrait --environment-variables coverage=true,coverageFile=/sdcard/coverage.ec --directories-to-pull=/sdcard --timeout 20m --directories-to-pull /sdcard/screenshots/journal.gratitude.com.gratitudejournal.test --results-bucket cloud-test-screenshotbot-example
       - run:
+          name: Create directory to store test results
+          command: mkdir firebase
+      - run:
           name: Download instrumented test results from Firebase Test Lab
           command: gsutil -m cp -r -U "`gsutil ls gs://cloud-test-screenshotbot-example | tail -1`*" /root/src/firebase/
       - run:
@@ -127,10 +130,6 @@ jobs:
               --api-key ${SCREENSHOTBOT_API_KEY} \
               --repo-url ${CIRCLE_REPOSITORY_URL} \
               --api-secret ${SCREENSHOTBOT_API_SECRET}
-
-      - run:
-          name: Create directory to store test results
-          command: mkdir firebase
       - *persist_firebase_workspace
       # - store_artifacts:
       #     path: firebase/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ jobs:
       - *decrypt_gcloud_key
       - run:
           name: Set Google Cloud target project
-          command: gcloud config set project screenshotbot-example
+          command: true  # gcloud config set project gratitude-journal-app
       - run:
           name: Authenticate with Google Cloud
           command: gcloud auth activate-service-account presently-cicd-service-account@gratitude-journal-app.iam.gserviceaccount.com --key-file ${HOME}/client-secret.json

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ jobs:
       - *decrypt_gcloud_key
       - run:
           name: Set Google Cloud target project
-          command: gcloud config set project gratitude-journal-app
+          command: gcloud config set project screenshotbot-example
       - run:
           name: Authenticate with Google Cloud
           command: gcloud auth activate-service-account presently-cicd-service-account@gratitude-journal-app.iam.gserviceaccount.com --key-file ${HOME}/client-secret.json
@@ -157,4 +157,3 @@ workflows:
           requires:
             - build_debug
             - test_instrumented
-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,7 +118,7 @@ jobs:
           name: Record to screenshotbot
           command: |
             curl https://screenshotbot.io/recorder.sh | sh
-            ~/screenshotbot/recorder \
+            cd ~/src && ~/screenshotbot/recorder \
               --directory ${CIRCLE_ARTIFACTS}/*/*/artifacts/screenshot_bundle.zip \
               --channel screenshotbot-example-circleci-test \
               --metadata ${CIRCLE_ARTIFACTS}/*/*/artifacts/metadata.xml \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,10 +104,10 @@ jobs:
       - *decrypt_gcloud_key
       - run:
           name: Set Google Cloud target project
-          command: gcloud config set project screenshotbot-example
+          command: gcloud config set project gratitude-journal-app
       - run:
           name: Authenticate with Google Cloud
-          command: gcloud auth activate-service-account --key-file ${HOME}/client-secret.json
+          command: gcloud auth activate-service-account presently-cicd-service-account@gratitude-journal-app.iam.gserviceaccount.com --key-file ${HOME}/client-secret.json
       - run:
           name: Run instrumented test on Firebase Test Lab
           command: gcloud firebase test android run --type instrumentation --app app/build/outputs/apk/debug/app-debug.apk --test app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk --device model=walleye,version=27,locale=en_US,orientation=portrait --environment-variables coverage=true,coverageFile=/sdcard/coverage.ec --directories-to-pull=/sdcard --timeout 20m --directories-to-pull /sdcard/screenshots/journal.gratitude.com.gratitudejournal.test --results-bucket cloud-test-screenshotbot-example
@@ -116,7 +116,7 @@ jobs:
           command: mkdir firebase
       - run:
           name: Download instrumented test results from Firebase Test Lab
-          command: gsutil -m cp -r -U "`gsutil ls gs://cloud-test-screenshotbot-example | tail -1`*" /root/src/firebase/
+          command: gsutil -m cp -r -U "`gsutil ls gs://test-lab-633h5cj3dy2zq-nfytdzn1u6s8i | tail -1`*" /root/src/firebase/
       - run:
           name: Record to screenshotbot
           command: |
@@ -131,9 +131,9 @@ jobs:
               --repo-url ${CIRCLE_REPOSITORY_URL} \
               --api-secret ${SCREENSHOTBOT_API_SECRET}
       - *persist_firebase_workspace
-      # - store_artifacts:
-      #     path: firebase/
-      #     destination: /firebase/
+      - store_artifacts:
+          path: firebase/
+          destination: /firebase/
 
   build_debug:
     <<: *android_config

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,7 @@ jobs:
       - *attach_firebase_workspace
       - run:
           name: Move Firebase coverage report
-          command: mkdir -p app/build/outputs/code-coverage/connected && cp firebase/walleye-28-en_US-portrait/artifacts/coverage.ec app/build/outputs/code-coverage/connected/coverage.ec
+          command: mkdir -p app/build/outputs/code-coverage/connected && cp firebase/walleye-27-en_US-portrait/artifacts/coverage.ec app/build/outputs/code-coverage/connected/coverage.ec
       - run:
           name: Generate JaCoCo report
           command: ./gradlew -PciBuild=true jacocoTestReport

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,7 @@ jobs:
           command: gcloud firebase test android run --type instrumentation --app app/build/outputs/apk/debug/app-debug.apk --test app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk --device model=walleye,version=27,locale=en_US,orientation=portrait --environment-variables coverage=true,coverageFile=/sdcard/coverage.ec --directories-to-pull=/sdcard --timeout 20m --directories-to-pull /sdcard/screenshots/journal.gratitude.com.gratitudejournal.test --results-bucket cloud-test-screenshotbot-example
       - run:
           name: Download instrumented test results from Firebase Test Lab
-          command: gsutil -m cp -r -U "`gsutil ls gs://test-lab-633h5cj3dy2zq-nfytdzn1u6s8i | tail -1`*" /root/src/firebase/
+          command: gsutil -m cp -r -U "`gsutil ls gs://cloud-test-screenshotbot-example | tail -1`*" /root/src/firebase/
       - run:
           name: Record to screenshotbot
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,7 +121,7 @@ jobs:
             curl https://screenshotbot.io/recorder.sh | sh
             cd ~/src && ~/screenshotbot/recorder \
               --directory ${CIRCLE_ARTIFACTS}/*/*/artifacts/screenshot_bundle.zip \
-              --channel screenshotbot-example-circleci-test \
+              --channel Presently \
               --metadata ${CIRCLE_ARTIFACTS}/*/*/artifacts/metadata.xml \
               --production \
               --branch ${CIRCLE_BRANCH} \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,12 +101,12 @@ jobs:
     steps:
       - *attach_debug_workspace
       - *decrypt_gcloud_key
-      # - run:
-      #     name: Set Google Cloud target project
-      #     command: gcloud config set project gratitude-journal-app
+      - run:
+          name: Set Google Cloud target project
+          command: gcloud config set project screenshotbot-example
       - run:
           name: Authenticate with Google Cloud
-          command: gcloud auth activate-service-account presently-cicd-service-account@gratitude-journal-app.iam.gserviceaccount.com --key-file ${HOME}/client-secret.json
+          command: gcloud auth activate-service-account --key-file ${HOME}/client-secret.json
       - run:
           name: Run instrumented test on Firebase Test Lab
           command: gcloud firebase test android run --type instrumentation --app app/build/outputs/apk/debug/app-debug.apk --test app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk --device model=walleye,version=28,locale=en_US,orientation=portrait --environment-variables coverage=true,coverageFile=/sdcard/coverage.ec --directories-to-pull=/sdcard --timeout 20m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,17 +112,16 @@ jobs:
           name: Run instrumented test on Firebase Test Lab
           command: gcloud firebase test android run --type instrumentation --app app/build/outputs/apk/debug/app-debug.apk --test app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk --device model=walleye,version=27,locale=en_US,orientation=portrait --environment-variables coverage=true,coverageFile=/sdcard/coverage.ec --directories-to-pull=/sdcard --timeout 20m --directories-to-pull /sdcard/screenshots/journal.gratitude.com.gratitudejournal.test --results-bucket cloud-test-screenshotbot-example
       - run:
-          name: Install gsutil dependency and copy test results data
-          command: |
-             gsutil -m cp -r -U `gsutil ls gs://cloud-test-screenshotbot-example/ | tail -1` ${CIRCLE_ARTIFACTS}/ | true
+          name: Download instrumented test results from Firebase Test Lab
+          command: gsutil -m cp -r -U "`gsutil ls gs://test-lab-633h5cj3dy2zq-nfytdzn1u6s8i | tail -1`*" /root/src/firebase/
       - run:
           name: Record to screenshotbot
           command: |
             curl https://screenshotbot.io/recorder.sh | sh
             cd ~/src && ~/screenshotbot/recorder \
-              --directory ${CIRCLE_ARTIFACTS}/*/*/artifacts/screenshot_bundle.zip \
+              --directory /root/src/firebase/*/*/artifacts/screenshot_bundle.zip \
               --channel Presently \
-              --metadata ${CIRCLE_ARTIFACTS}/*/*/artifacts/metadata.xml \
+              --metadata /root/src/firebase/*/*/artifacts/metadata.xml \
               --production \
               --branch ${CIRCLE_BRANCH} \
               --api-key ${SCREENSHOTBOT_API_KEY} \
@@ -132,9 +131,6 @@ jobs:
       - run:
           name: Create directory to store test results
           command: mkdir firebase
-      # - run:
-      #     name: Download instrumented test results from Firebase Test Lab
-      #     command: gsutil -m cp -r -U "`gsutil ls gs://test-lab-633h5cj3dy2zq-nfytdzn1u6s8i | tail -1`*" /root/src/firebase/
       - *persist_firebase_workspace
       # - store_artifacts:
       #     path: firebase/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,17 +109,35 @@ jobs:
           command: gcloud auth activate-service-account --key-file ${HOME}/client-secret.json
       - run:
           name: Run instrumented test on Firebase Test Lab
-          command: gcloud firebase test android run --type instrumentation --app app/build/outputs/apk/debug/app-debug.apk --test app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk --device model=walleye,version=28,locale=en_US,orientation=portrait --environment-variables coverage=true,coverageFile=/sdcard/coverage.ec --directories-to-pull=/sdcard --timeout 20m
+          command: gcloud firebase test android run --type instrumentation --app app/build/outputs/apk/debug/app-debug.apk --test app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk --device model=walleye,version=27,locale=en_US,orientation=portrait --environment-variables coverage=true,coverageFile=/sdcard/coverage.ec --directories-to-pull=/sdcard --timeout 20m --directories-to-pull /sdcard/screenshots/journal.gratitude.com.gratitudejournal.test --results-bucket cloud-test-screenshotbot-example
+      - run:
+          name: Install gsutil dependency and copy test results data
+          command: |
+             gsutil -m cp -r -U `sudo gsutil ls gs://cloud-test-screenshotbot-example/ | tail -1` ${CIRCLE_ARTIFACTS}/ | true
+      - run:
+          name: Record to screenshotbot
+          command: |
+            curl https://screenshotbot.io/recorder.sh | sh
+            ~/screenshotbot/recorder \
+              --directory ${CIRCLE_ARTIFACTS}/*/*/artifacts/screenshot_bundle.zip \
+              --channel screenshotbot-example-circleci-test \
+              --metadata ${CIRCLE_ARTIFACTS}/*/*/artifacts/metadata.xml \
+              --production \
+              --branch ${CIRCLE_BRANCH} \
+              --api-key ${SCREENSHOTBOT_API_KEY} \
+              --repo-url ${CIRCLE_REPOSITORY_URL} \
+              --api-secret ${SCREENSHOTBOT_API_SECRET}
+
       - run:
           name: Create directory to store test results
           command: mkdir firebase
-      - run:
-          name: Download instrumented test results from Firebase Test Lab
-          command: gsutil -m cp -r -U "`gsutil ls gs://test-lab-633h5cj3dy2zq-nfytdzn1u6s8i | tail -1`*" /root/src/firebase/
+      # - run:
+      #     name: Download instrumented test results from Firebase Test Lab
+      #     command: gsutil -m cp -r -U "`gsutil ls gs://test-lab-633h5cj3dy2zq-nfytdzn1u6s8i | tail -1`*" /root/src/firebase/
       - *persist_firebase_workspace
-      - store_artifacts:
-          path: firebase/
-          destination: /firebase/
+      # - store_artifacts:
+      #     path: firebase/
+      #     destination: /firebase/
 
   build_debug:
     <<: *android_config

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,7 @@ jobs:
       - run:
           name: Install gsutil dependency and copy test results data
           command: |
-             gsutil -m cp -r -U `sudo gsutil ls gs://cloud-test-screenshotbot-example/ | tail -1` ${CIRCLE_ARTIFACTS}/ | true
+             gsutil -m cp -r -U `gsutil ls gs://cloud-test-screenshotbot-example/ | tail -1` ${CIRCLE_ARTIFACTS}/ | true
       - run:
           name: Record to screenshotbot
           command: |

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,1 +1,2 @@
 /build
+/screenshots

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,6 +8,7 @@ apply plugin: 'androidx.navigation.safeargs.kotlin'
 apply plugin: 'com.google.android.gms.oss-licenses-plugin'
 apply plugin: 'com.google.gms.google-services'
 apply plugin: 'com.google.firebase.crashlytics'
+apply plugin: 'com.facebook.testing.screenshot'
 
 allOpen {
     annotation 'journal.gratitude.com.gratitudejournal.util.OpenClass'

--- a/app/src/androidTest/java/journal/gratitude/com/gratitudejournal/CustomTestRunner.kt
+++ b/app/src/androidTest/java/journal/gratitude/com/gratitudejournal/CustomTestRunner.kt
@@ -2,7 +2,9 @@ package journal.gratitude.com.gratitudejournal
 
 import android.app.Application
 import android.content.Context
+import android.os.Bundle
 import androidx.test.runner.AndroidJUnitRunner
+import com.facebook.testing.screenshot.ScreenshotRunner
 import journal.gratitude.com.gratitudejournal.di.TestGratitudeApplication
 
 /**
@@ -13,5 +15,15 @@ class CustomTestRunner : AndroidJUnitRunner() {
 
     override fun newApplication(cl: ClassLoader?, name: String?, context: Context?): Application {
         return super.newApplication(cl, TestGratitudeApplication::class.java.name, context)
+    }
+
+    override fun onCreate(args: Bundle) {
+        ScreenshotRunner.onCreate(this, args)
+        super.onCreate(args)
+    }
+
+    override fun finish(resultCode: Int, results: Bundle) {
+        ScreenshotRunner.onDestroy()
+        super.finish(resultCode, results)
     }
 }

--- a/app/src/androidTest/java/journal/gratitude/com/gratitudejournal/ui/CelebrateDialogFragmentInstrumentedTest.kt
+++ b/app/src/androidTest/java/journal/gratitude/com/gratitudejournal/ui/CelebrateDialogFragmentInstrumentedTest.kt
@@ -48,6 +48,7 @@ class CelebrateDialogFragmentInstrumentedTest {
             )
         )
 
+
         Intents.release()
     }
 

--- a/app/src/androidTest/java/journal/gratitude/com/gratitudejournal/ui/EntryFragmentInstrumentedTest.kt
+++ b/app/src/androidTest/java/journal/gratitude/com/gratitudejournal/ui/EntryFragmentInstrumentedTest.kt
@@ -5,6 +5,7 @@ import android.app.Instrumentation
 import android.content.Intent
 import android.view.KeyEvent
 import android.view.View
+import android.widget.TextView
 import androidx.fragment.app.testing.launchFragmentInContainer
 import androidx.navigation.NavController
 import androidx.navigation.Navigation

--- a/app/src/androidTest/java/journal/gratitude/com/gratitudejournal/ui/EntryFragmentInstrumentedTest.kt
+++ b/app/src/androidTest/java/journal/gratitude/com/gratitudejournal/ui/EntryFragmentInstrumentedTest.kt
@@ -4,10 +4,12 @@ import android.app.Activity
 import android.app.Instrumentation
 import android.content.Intent
 import android.view.KeyEvent
+import android.view.View
 import androidx.fragment.app.testing.launchFragmentInContainer
 import androidx.navigation.NavController
 import androidx.navigation.Navigation
 import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.ViewAction
 import androidx.test.espresso.action.ViewActions.*
 import androidx.test.espresso.assertion.ViewAssertions
 import androidx.test.espresso.assertion.ViewAssertions.matches
@@ -18,6 +20,7 @@ import androidx.test.espresso.intent.matcher.IntentMatchers.*
 import androidx.test.espresso.matcher.RootMatchers.isDialog
 import androidx.test.espresso.matcher.RootMatchers.withDecorView
 import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.espresso.UiController
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
@@ -34,7 +37,9 @@ import journal.gratitude.com.gratitudejournal.testUtils.saveEntryBlocking
 import journal.gratitude.com.gratitudejournal.testUtils.waitFor
 import journal.gratitude.com.gratitudejournal.ui.entry.EntryFragment
 import journal.gratitude.com.gratitudejournal.ui.entry.EntryFragmentArgs
+import org.hamcrest.CoreMatchers.any
 import org.hamcrest.CoreMatchers.not
+import org.hamcrest.Matcher
 import org.hamcrest.Matchers.allOf
 import org.junit.Before
 import org.junit.Rule
@@ -72,7 +77,7 @@ class EntryFragmentInstrumentedTest {
             fragmentArgs = bundle.toBundle()
         )
 
-
+        removeInspiration()
         onView(withId(android.R.id.content))
            .perform(screenshot("writtenEntry_showsShareButton"))
 
@@ -96,6 +101,7 @@ class EntryFragmentInstrumentedTest {
             fragmentArgs = args.toBundle()
         )
 
+        removeInspiration()
         onView(withId(android.R.id.content))
             .perform(screenshot("noEntry_showsPromptButton"))
 
@@ -117,6 +123,7 @@ class EntryFragmentInstrumentedTest {
             fragmentArgs = args.toBundle()
         )
 
+        removeInspiration()
         onView(withId(android.R.id.content))
             .perform(screenshot("promptButton_changesHintText"))
 
@@ -155,6 +162,7 @@ class EntryFragmentInstrumentedTest {
             )
         )
 
+        removeInspiration()
         onView(withId(android.R.id.content))
             .perform(screenshot("shareButton_opensShareActivity"))
 
@@ -347,6 +355,22 @@ class EntryFragmentInstrumentedTest {
         verify(mockNavController).navigateUp()
 
         onView(withText(R.string.are_you_sure)).check(ViewAssertions.doesNotExist())
+    }
+
+    // Make the inspiration message deterministic for screenshot tests
+    fun removeInspiration() {
+        // There's probably a less verbose way to do this correctly,
+        // but this works for now.
+        onView(withId(R.id.inspiration))
+            .perform(object: ViewAction {
+                         override fun getConstraints(): Matcher<View> = any(View::class.java)
+
+                         override fun getDescription() = "Make inspiration message deterministic"
+                         override fun perform(uiController: UiController, view: View) {
+                             val tv = view as TextView
+                             tv.setText("\"This is a wonderful day. I\'ve never seen this day before\" \nMaya Angelou");
+                         }
+            });
     }
 
 }

--- a/app/src/androidTest/java/journal/gratitude/com/gratitudejournal/ui/EntryFragmentInstrumentedTest.kt
+++ b/app/src/androidTest/java/journal/gratitude/com/gratitudejournal/ui/EntryFragmentInstrumentedTest.kt
@@ -80,7 +80,7 @@ class EntryFragmentInstrumentedTest {
 
         removeInspiration()
         onView(withId(android.R.id.content))
-           .perform(screenshot("writtenEntry_showsShareButton"))
+           .perform(screenshot())
 
         onView(withId(R.id.share_button))
             .check(matches(isDisplayed()))
@@ -104,7 +104,7 @@ class EntryFragmentInstrumentedTest {
 
         removeInspiration()
         onView(withId(android.R.id.content))
-            .perform(screenshot("noEntry_showsPromptButton"))
+            .perform(screenshot())
 
         onView(withId(R.id.share_button)).check(matches(not(isDisplayed())))
         onView(withId(R.id.prompt_button)).check(matches(isDisplayed()))
@@ -126,7 +126,7 @@ class EntryFragmentInstrumentedTest {
 
         removeInspiration()
         onView(withId(android.R.id.content))
-            .perform(screenshot("promptButton_changesHintText"))
+            .perform(screenshot())
 
         onView(withId(R.id.entry_text)).check(matches(withHint("What were you grateful for?")))
         onView(withId(R.id.prompt_button)).perform(click())
@@ -165,7 +165,7 @@ class EntryFragmentInstrumentedTest {
 
         removeInspiration()
         onView(withId(android.R.id.content))
-            .perform(screenshot("shareButton_opensShareActivity"))
+            .perform(screenshot())
 
         Intents.release()
     }

--- a/app/src/androidTest/java/journal/gratitude/com/gratitudejournal/ui/EntryFragmentInstrumentedTest.kt
+++ b/app/src/androidTest/java/journal/gratitude/com/gratitudejournal/ui/EntryFragmentInstrumentedTest.kt
@@ -21,6 +21,7 @@ import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
+import com.facebook.testing.screenshot.Screenshot
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import journal.gratitude.com.gratitudejournal.R
@@ -71,6 +72,10 @@ class EntryFragmentInstrumentedTest {
             fragmentArgs = bundle.toBundle()
         )
 
+
+        onView(withId(android.R.id.content))
+           .perform(screenshot("writtenEntry_showsShareButton"))
+
         onView(withId(R.id.share_button))
             .check(matches(isDisplayed()))
         onView(withId(R.id.prompt_button))
@@ -91,6 +96,9 @@ class EntryFragmentInstrumentedTest {
             fragmentArgs = args.toBundle()
         )
 
+        onView(withId(android.R.id.content))
+            .perform(screenshot("noEntry_showsPromptButton"))
+
         onView(withId(R.id.share_button)).check(matches(not(isDisplayed())))
         onView(withId(R.id.prompt_button)).check(matches(isDisplayed()))
     }
@@ -108,6 +116,9 @@ class EntryFragmentInstrumentedTest {
             themeResId = R.style.Base_AppTheme,
             fragmentArgs = args.toBundle()
         )
+
+        onView(withId(android.R.id.content))
+            .perform(screenshot("promptButton_changesHintText"))
 
         onView(withId(R.id.entry_text)).check(matches(withHint("What were you grateful for?")))
         onView(withId(R.id.prompt_button)).perform(click())
@@ -143,6 +154,9 @@ class EntryFragmentInstrumentedTest {
                 hasExtra(Intent.EXTRA_TITLE, "Share your gratitude progress")
             )
         )
+
+        onView(withId(android.R.id.content))
+            .perform(screenshot("shareButton_opensShareActivity"))
 
         Intents.release()
     }

--- a/app/src/androidTest/java/journal/gratitude/com/gratitudejournal/ui/ScreenshotAction.kt
+++ b/app/src/androidTest/java/journal/gratitude/com/gratitudejournal/ui/ScreenshotAction.kt
@@ -6,8 +6,11 @@ import org.hamcrest.Matcher
 import com.facebook.testing.screenshot.Screenshot
 import android.view.View
 import androidx.test.espresso.UiController
+import com.facebook.testing.screenshot.internal.TestNameDetector
 
 fun screenshot(name: String)  = ScreenshotAction(name)
+
+fun screenshot() = screenshot(TestNameDetector.getTestName())
 
 class ScreenshotAction(val name: String) : ViewAction {
     override fun getConstraints(): Matcher<View> = any(View::class.java)

--- a/app/src/androidTest/java/journal/gratitude/com/gratitudejournal/ui/ScreenshotAction.kt
+++ b/app/src/androidTest/java/journal/gratitude/com/gratitudejournal/ui/ScreenshotAction.kt
@@ -1,0 +1,22 @@
+package journal.gratitude.com.gratitudejournal.ui
+
+import androidx.test.espresso.ViewAction
+import org.hamcrest.CoreMatchers.any
+import org.hamcrest.Matcher
+import com.facebook.testing.screenshot.Screenshot
+import android.view.View
+import androidx.test.espresso.UiController
+
+fun screenshot(name: String)  = ScreenshotAction(name)
+
+class ScreenshotAction(val name: String) : ViewAction {
+    override fun getConstraints(): Matcher<View> = any(View::class.java)
+
+    override fun getDescription() = "Record screenshot of View"
+
+    override fun perform(uiController: UiController, view: View) {
+        Screenshot.snap(view)
+            .setName(name)
+            .record();
+    }
+}

--- a/app/src/androidTest/java/journal/gratitude/com/gratitudejournal/ui/SearchFragmentInstrumentedTest.kt
+++ b/app/src/androidTest/java/journal/gratitude/com/gratitudejournal/ui/SearchFragmentInstrumentedTest.kt
@@ -52,7 +52,7 @@ class SearchFragmentInstrumentedTest {
 
         onView(withId(R.id.back_icon)).perform(click())
         onView(withId(android.R.id.content))
-            .perform(screenshot("search_pressBackButton_navigateUp"))
+            .perform(screenshot())
 
         verify(mockNavController).navigateUp()
     }

--- a/app/src/androidTest/java/journal/gratitude/com/gratitudejournal/ui/SearchFragmentInstrumentedTest.kt
+++ b/app/src/androidTest/java/journal/gratitude/com/gratitudejournal/ui/SearchFragmentInstrumentedTest.kt
@@ -51,6 +51,8 @@ class SearchFragmentInstrumentedTest {
         }
 
         onView(withId(R.id.back_icon)).perform(click())
+        onView(withId(android.R.id.content))
+            .perform(screenshot("search_pressBackButton_navigateUp"))
 
         verify(mockNavController).navigateUp()
     }

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ buildscript {
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:$navigation_version"
         classpath 'com.google.android.gms:oss-licenses-plugin:0.10.2'
         classpath 'com.google.firebase:firebase-crashlytics-gradle:2.2.0'
+        classpath 'com.facebook.testing.screenshot:plugin:0.13.0'
     }
 }
 


### PR DESCRIPTION
## :scroll: Description

We talked over Email, and I wanted to build out the skeleton of Screenshot tests. It's not ideal to use screenshot-tests-for-android with Espresso tests because it's hard to control for non-determinism, but in this case, since you already had many Espresso tests, I figured it was best to plug it in here. I built a nice ViewAction to make it easier to write these tests, perhaps I should upstream that to screenshot-tests-for-android.

## :green_heart: How did you test it?
So this was the tricky part. I tested it on my CircleCI account, but had to make many temporary modifications to the config.yml (gcloud bucket, google project etc.) So I didn't test on the exact version that's in this Pull Request, but I tested on a very close version. If any thing fails it should be easy to resolve the issues.

## :camera_flash: Screenshots / GIFs

Here's an example image generated by the new runs:
<img src="https://screenshotbot.io/image/blob/603e1fc6c4519f6338c0f153/default.png" />

To be clear this was generated from the tests. 

Extra notes:

Feel free to squash the commits. I had lots of tiny commits that I chose not to squash for now because it's easier for me to undo changes for testing on CircleCI.
Also, as mentioned in the email, you would have to add SCREENSHOTBOT_API_KEY and SCREENSHOTBOT_API_SECRET environment variables for the build to be green. If you also want to start seeing Screenshotbot notices on PRs (it won't show on this PR because it's the absolute first PR, so there's no baseline image to compare against) you will also need to install the Screenshotbot app from Github marketplace.

Finally, I'm always around for support or questions. I mentioned we're still small, but that means we can promise you priority and even bespoke support if you need it.
<!-- <img src="https://user-images.githubusercontent.com/883468/93824506-8ef15880-fc31-11ea-9f44-ca32bb0de88a.jpg" width="260"/> -->
