### PR TITLE
[Fix] Not saving entire entry

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,7 +21,7 @@ android {
         minSdkVersion project.ext.androidMinSdk
         targetSdkVersion project.ext.androidTargetSdk
 
-        versionCode 66
+        versionCode 67
         versionName project.ext.androidVersionName
         //TODO wire up to CI
         //buildConfigField 'int', 'BUILD_NUMBER', "${project.ext.buildNumber}"

--- a/app/src/main/java/journal/gratitude/com/gratitudejournal/ui/entry/EntryFragment.kt
+++ b/app/src/main/java/journal/gratitude/com/gratitudejournal/ui/entry/EntryFragment.kt
@@ -103,7 +103,7 @@ class EntryFragment : Fragment(R.layout.entry_fragment), MavericksView {
         }
 
         save_button.setOnClickListener {
-            saveEntry()
+            viewModel.saveEntry()
         }
 
         val showQuote = sharedPrefs.getBoolean("show_quote", true)
@@ -128,9 +128,10 @@ class EntryFragment : Fragment(R.layout.entry_fragment), MavericksView {
 
         lifecycleScope.launch {
             entry_text.textChanges()
-                .debounce(300)
-                .map { charSequence -> charSequence.toString() }
-                .drop(1)
+                .debounce(200)
+                .map { charSequence ->
+                    charSequence.toString()
+                }
                 .collectLatest {
                     viewModel.onTextChanged(it)
                 }
@@ -157,6 +158,9 @@ class EntryFragment : Fragment(R.layout.entry_fragment), MavericksView {
         setEditText(state.entryContent)
         share_button.isVisible = !state.isEmpty
         prompt_button.isVisible = state.isEmpty
+        if (state.isSaved) {
+            onEntrySaved()
+        }
     }
 
     private fun getHintString(date: LocalDate) = resources.getString(
@@ -187,7 +191,7 @@ class EntryFragment : Fragment(R.layout.entry_fragment), MavericksView {
         setStatusBarColorsForBackground(window, typedValue.data)
     }
 
-    private fun saveEntry() {
+    private fun onEntrySaved() {
         val numEntries = args.numEntries
         val isNewEntry = args.isNewEntry
 
@@ -203,7 +207,6 @@ class EntryFragment : Fragment(R.layout.entry_fragment), MavericksView {
         } else {
             firebaseAnalytics.logEvent(EDITED_EXISTING_ENTRY, null)
         }
-
         viewModel.saveEntry()
         val imm =
             activity?.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager?

--- a/app/src/main/java/journal/gratitude/com/gratitudejournal/ui/entry/EntryState.kt
+++ b/app/src/main/java/journal/gratitude/com/gratitudejournal/ui/entry/EntryState.kt
@@ -10,7 +10,8 @@ data class EntryState(
     val quote: String,
     val hasUserEdits: Boolean,
     val promptNumber: Int,
-    val promptsList: List<String>
+    val promptsList: List<String>,
+    val isSaved: Boolean
 ) : MavericksState {
     val isEmpty = entryContent.isEmpty()
 }

--- a/app/src/main/java/journal/gratitude/com/gratitudejournal/ui/entry/EntryViewModel.kt
+++ b/app/src/main/java/journal/gratitude/com/gratitudejournal/ui/entry/EntryViewModel.kt
@@ -30,8 +30,12 @@ class EntryViewModel @AssistedInject constructor(
     }
 
     fun onTextChanged(newText: String) {
-        setState {
-            copy(entryContent = newText, hasUserEdits = true)
+        withState { oldState ->
+            if (oldState.entryContent != newText) {
+                setState {
+                    copy(entryContent = newText, hasUserEdits = true)
+                }
+            }
         }
     }
 
@@ -40,6 +44,9 @@ class EntryViewModel @AssistedInject constructor(
             val entry = Entry(it.date, it.entryContent)
             viewModelScope.launch(Dispatchers.IO) {
                 repository.addEntry(entry)
+                setState {
+                    copy(isSaved = true)
+                }
             }
         }
     }
@@ -69,7 +76,7 @@ class EntryViewModel @AssistedInject constructor(
             val prompts = viewModelContext.activity.resources.getStringArray(R.array.prompts)
             prompts.shuffle() //randomise prompts
             val quote = viewModelContext.activity.resources.getStringArray(R.array.inspirations).random()
-            return EntryState(passedInDate, "", null, quote, false, 0, prompts.toList())
+            return EntryState(passedInDate, "", null, quote, false, 0, prompts.toList(), false)
         }
 
         override fun create(viewModelContext: ViewModelContext, state: EntryState): EntryViewModel {

--- a/app/src/test/java/journal/gratitude/com/gratitudejournal/ui/entry/EntryViewModelTest.kt
+++ b/app/src/test/java/journal/gratitude/com/gratitudejournal/ui/entry/EntryViewModelTest.kt
@@ -63,7 +63,7 @@ class EntryViewModelTest {
 
     @Test
     fun `GIVEN entry view model WHEN changePrompt is called THEN the state is updated`() {
-        val initialState = EntryState(LocalDate.now(), "", null, "quote", false, 0, listOf("one", "two"))
+        val initialState = EntryState(LocalDate.now(), "", null, "quote", false, 0, listOf("one", "two"), false)
         viewModel = EntryViewModel(initialState, repository)
         viewModel.changePrompt()
 
@@ -75,7 +75,7 @@ class EntryViewModelTest {
 
     @Test
     fun `GIVEN entry view model WHEN onTextChanged is called THEN the state is updated`() {
-        val initialState = EntryState(LocalDate.now(), "", null, "quote", false, 0, listOf("one", "two"))
+        val initialState = EntryState(LocalDate.now(), "", null, "quote", false, 0, listOf("one", "two"), false)
         viewModel = EntryViewModel(initialState, repository)
         viewModel.onTextChanged("new text")
 
@@ -87,7 +87,7 @@ class EntryViewModelTest {
 
     @Test
     fun `GIVEN entry view model WHEN setDate is called THEN the state is updated`() {
-        val initialState = EntryState(LocalDate.now(), "", null, "quote", false, 0, listOf("one", "two"))
+        val initialState = EntryState(LocalDate.now(), "", null, "quote", false, 0, listOf("one", "two"), false)
         viewModel = EntryViewModel(initialState, repository)
         viewModel.setDate("2021-03-02")
 

--- a/versions.gradle
+++ b/versions.gradle
@@ -1,6 +1,6 @@
 ext {
     major = 1
-    minor = 12
+    minor = 13
     patch = 0
     beta = ""
 


### PR DESCRIPTION
## :scroll: Description
Some users had been reporting that their entries were not entirely saving, or weren't saving at all when they clicked the save button. This is a new issue since rewriting the entry screen with Mavericks and coroutines. 

The only way I'm able to repro this is if I type quickly and then click the save button immediately. This lead me to believe that the issue was my new debounce logic. I lowered the debounce time and refactored the code so I no longer have to drop the first change to the text field (this was to handle the case when viewing an existing entry and we set the edittext to have the existing content.

Unfortunately users report that this issue happens even when they wait some time before clicking save. Until I have more information and can consistently reproduce this will be the fix.  

## :green_heart: How did you test it?
Lots of manual testing and updated unit tests.

