### PR TITLE
Refactor to replace milestones set with isMilestone function

### DIFF
--- a/app/src/main/java/journal/gratitude/com/gratitudejournal/model/TimelineItems.kt
+++ b/app/src/main/java/journal/gratitude/com/gratitudejournal/model/TimelineItems.kt
@@ -17,10 +17,12 @@ data class Milestone(val number: Int,
                      val numString: String): TimelineItem() {
 
     companion object {
-        val milestones = setOf(5, 10, 25, 50, 75, 100, 125, 150, 175, 200, 225, 250, 275, 300, 325, 365, 400, 425, 450, 475, 500, 525, 550, 575, 600)
+        fun isMilestone(number: Int): Boolean {
+            return number == 5 || number == 10 || (number % 25) == 0
+        }
 
         fun create(number: Int): Milestone {
-            require(milestones.contains(number))
+            require(isMilestone(number))
 
             return Milestone(number, number.toString())
         }

--- a/app/src/main/java/journal/gratitude/com/gratitudejournal/ui/entry/EntryViewModel.kt
+++ b/app/src/main/java/journal/gratitude/com/gratitudejournal/ui/entry/EntryViewModel.kt
@@ -11,7 +11,7 @@ import dagger.assisted.AssistedInject
 import journal.gratitude.com.gratitudejournal.model.CLICKED_PROMPT
 import journal.gratitude.com.gratitudejournal.model.EDITED_EXISTING_ENTRY
 import journal.gratitude.com.gratitudejournal.model.Entry
-import journal.gratitude.com.gratitudejournal.model.Milestone
+import journal.gratitude.com.gratitudejournal.model.Milestone.Companion.isMilestone
 import journal.gratitude.com.gratitudejournal.repository.EntryRepository
 import kotlinx.coroutines.launch
 
@@ -67,7 +67,7 @@ class EntryViewModel @AssistedInject constructor(
             if (it.isNewEntry) {
                 val totalEntries = (it.numberExistingEntries ?: 0) + 1
                 analytics.recordEntryAdded(totalEntries)
-                if (Milestone.milestones.contains(totalEntries)) {
+                if (isMilestone(totalEntries)) {
                     setState {
                         copy(milestoneNumber = totalEntries)
                     }

--- a/app/src/main/java/journal/gratitude/com/gratitudejournal/ui/timeline/TimelineViewModel.kt
+++ b/app/src/main/java/journal/gratitude/com/gratitudejournal/ui/timeline/TimelineViewModel.kt
@@ -6,7 +6,7 @@ import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import journal.gratitude.com.gratitudejournal.model.Entry
 import journal.gratitude.com.gratitudejournal.model.Milestone
-import journal.gratitude.com.gratitudejournal.model.Milestone.Companion.milestones
+import journal.gratitude.com.gratitudejournal.model.Milestone.Companion.isMilestone
 import journal.gratitude.com.gratitudejournal.model.TimelineItem
 import journal.gratitude.com.gratitudejournal.repository.EntryRepository
 import kotlinx.coroutines.CoroutineScope
@@ -73,7 +73,7 @@ class TimelineViewModel @Inject constructor(private val repository: EntryReposit
                             listWithHintsAndMilestones.add(0, listWithHints[index])
                             if (listWithHints[index].entryContent.isNotEmpty()) {
                                 numEntries++
-                                if (milestones.contains(numEntries)) {
+                                if (isMilestone(numEntries)) {
                                     listWithHintsAndMilestones.add(0, Milestone.create(numEntries))
                                 }
                             }


### PR DESCRIPTION
Signed-off-by: Jay Clark <jay@jayeclark.dev>

## :scroll: Description
Fixes #251. Removes milestone set definition and replaces with an isMilestone function that evaluates whether a given integer is 5, 10, or a multiple of 25. 

## :green_heart: How did you test it?
Existing unit tests.

**NOTE: I'm unsure how to address the CI failure as it's not related to my code changes, and if I update the code to include a boilerplate local.properties file to get it to pass the tests, that change definitely shouldn't be merged into the original repo as it will have a nonsense value in it for DROPBOX_KEY.**

## :camera_flash: Screenshots / GIFs
Not applicable.

<!-- <img src="https://user-images.githubusercontent.com/883468/93824506-8ef15880-fc31-11ea-9f44-ca32bb0de88a.jpg" width="260"/> -->
