### PR TITLE
Remove method coverage requirements

### DIFF
--- a/gradle/jacoco_ci.gradle
+++ b/gradle/jacoco_ci.gradle
@@ -167,7 +167,6 @@ def printReport(task) {
     metrics << [
             'instruction': percentage(counters.find { it.'@type'.equals('INSTRUCTION') }),
             'line'       : percentage(counters.find { it.'@type'.equals('LINE') }),
-            'method'     : percentage(counters.find { it.'@type'.equals('METHOD') }),
             'class'      : percentage(counters.find { it.'@type'.equals('CLASS') })
     ]
 
@@ -178,7 +177,6 @@ def printReport(task) {
     def minTestCoverage = [
             'instruction': 80,
             'line'       : 80,
-            'method'     : 77,
             'class'      : 80
     ]
 


### PR DESCRIPTION
## :scroll: Description
The mavericks/jacoco coverage issue as described [here](https://github.com/airbnb/mavericks/issues/552) makes it very difficult to reach the method code coverage requirements. I'm removing the coverage requirements for this so that we don't block Mavericks code from releasing.

## :green_heart: How did you test it?
CI

