### PR TITLE
fix: New entry not getting reset

### DIFF
--- a/app/src/androidTest/java/journal/gratitude/com/gratitudejournal/ui/EntryFragmentInstrumentedTest.kt
+++ b/app/src/androidTest/java/journal/gratitude/com/gratitudejournal/ui/EntryFragmentInstrumentedTest.kt
@@ -310,15 +310,14 @@ class EntryFragmentInstrumentedTest {
         onView(withText(R.string.are_you_sure)).check(matches(isDisplayed()))
 
         //cancel is pressed
-        onView(withId(android.R.id.button2)).perform(click())
+        onView(withId(android.R.id.button1)).perform(click())
         onView(withText(R.string.are_you_sure)).check(ViewAssertions.doesNotExist())
 
         //back pressed again
         mDevice.pressBack()
 
         //continue clicked
-        onView(withId(android.R.id.button1)).perform(click())
-
+        onView(withId(android.R.id.button2)).perform(click())
         onView(withText(R.string.are_you_sure)).check(ViewAssertions.doesNotExist())
     }
 

--- a/app/src/main/java/journal/gratitude/com/gratitudejournal/ui/entry/EntryFragment.kt
+++ b/app/src/main/java/journal/gratitude/com/gratitudejournal/ui/entry/EntryFragment.kt
@@ -67,7 +67,7 @@ class EntryFragment : Fragment(), MavericksView, EntryScreenCallbacks {
         val callback = object : OnBackPressedCallback(true) {
             override fun handleOnBackPressed() {
                 withState(viewModel) {
-                    if (it.editsWereMade) {
+                    if (it.hasUserEdits) {
                         showUnsavedEntryDialog(false)
                     } else {
                         requireActivity().supportFragmentManager.popBackStack()
@@ -190,7 +190,7 @@ class EntryFragment : Fragment(), MavericksView, EntryScreenCallbacks {
 
     private fun setEditText(newText: String) {
         val oldText = binding.entryText.text.toString()
-        if (newText != oldText && newText.isNotEmpty()) {
+        if (newText != oldText) {
             binding.entryText.setText(newText)
             binding.entryText.setSelection(newText.length)
         }
@@ -212,8 +212,7 @@ class EntryFragment : Fragment(), MavericksView, EntryScreenCallbacks {
     }
 
     override fun hideKeyboard() {
-        val imm =
-            activity?.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager?
+        val imm = activity?.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager?
         imm?.hideSoftInputFromWindow(binding.entryText.windowToken, 0)
     }
 
@@ -303,7 +302,7 @@ class EntryFragment : Fragment(), MavericksView, EntryScreenCallbacks {
         showUnsavedEntryDialog(true)
     }
 
-    override fun anyEditsMade() = withState(viewModel) { it.editsWereMade }
+    override fun anyEditsMade() = withState(viewModel) { it.hasUserEdits }
 
     private var parentCallback: (() -> Unit)? = null
     override fun setParentCallback(action: () -> Unit) {

--- a/app/src/main/java/journal/gratitude/com/gratitudejournal/ui/entry/EntryFragment.kt
+++ b/app/src/main/java/journal/gratitude/com/gratitudejournal/ui/entry/EntryFragment.kt
@@ -1,6 +1,8 @@
 package journal.gratitude.com.gratitudejournal.ui.entry
 
-import android.content.*
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
 import android.content.res.Resources
 import android.graphics.Color
 import android.graphics.drawable.Animatable
@@ -30,16 +32,17 @@ import com.presently.logging.AnalyticsLogger
 import com.presently.settings.BackupCadence
 import com.presently.settings.PresentlySettings
 import com.presently.sharing.view.SharingFragment
-import journal.gratitude.com.gratitudejournal.R
-import journal.gratitude.com.gratitudejournal.model.*
-import journal.gratitude.com.gratitudejournal.ui.dialog.CelebrateDialogFragment
-import journal.gratitude.com.gratitudejournal.util.backups.UploadToCloudWorker
-import journal.gratitude.com.gratitudejournal.util.backups.dropbox.DropboxUploader
 import com.presently.ui.setStatusBarColorsForBackground
 import dagger.hilt.android.AndroidEntryPoint
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
+import journal.gratitude.com.gratitudejournal.R
 import journal.gratitude.com.gratitudejournal.databinding.EntryFragmentBinding
+import journal.gratitude.com.gratitudejournal.model.COPIED_QUOTE
+import journal.gratitude.com.gratitudejournal.model.SHARED_ENTRY
+import journal.gratitude.com.gratitudejournal.ui.dialog.CelebrateDialogFragment
+import journal.gratitude.com.gratitudejournal.util.backups.UploadToCloudWorker
+import journal.gratitude.com.gratitudejournal.util.backups.dropbox.DropboxUploader
 import journal.gratitude.com.gratitudejournal.util.toFullString
 import org.threeten.bp.LocalDate
 import java.util.concurrent.TimeUnit
@@ -67,7 +70,7 @@ class EntryFragment : Fragment(), MavericksView, EntryScreenCallbacks {
         val callback = object : OnBackPressedCallback(true) {
             override fun handleOnBackPressed() {
                 withState(viewModel) {
-                    if (it.hasUserEdits) {
+                    if (it.hasUserEdits && it.editsWereMade) {
                         showUnsavedEntryDialog(false)
                     } else {
                         requireActivity().supportFragmentManager.popBackStack()
@@ -302,7 +305,7 @@ class EntryFragment : Fragment(), MavericksView, EntryScreenCallbacks {
         showUnsavedEntryDialog(true)
     }
 
-    override fun anyEditsMade() = withState(viewModel) { it.hasUserEdits }
+    override fun anyEditsMade() = withState(viewModel) { it.editsWereMade }
 
     private var parentCallback: (() -> Unit)? = null
     override fun setParentCallback(action: () -> Unit) {

--- a/app/src/main/java/journal/gratitude/com/gratitudejournal/ui/entry/EntryState.kt
+++ b/app/src/main/java/journal/gratitude/com/gratitudejournal/ui/entry/EntryState.kt
@@ -47,5 +47,7 @@ data class EntryState(
     )
 
     val isEmpty = entryContent.isEmpty()
+    val editsWereMade = (hasUserEdits && (isNewEntry && isEmpty).not())
+
 
 }

--- a/app/src/main/java/journal/gratitude/com/gratitudejournal/ui/entry/EntryState.kt
+++ b/app/src/main/java/journal/gratitude/com/gratitudejournal/ui/entry/EntryState.kt
@@ -47,7 +47,7 @@ data class EntryState(
     )
 
     val isEmpty = entryContent.isEmpty()
-    val editsWereMade = (hasUserEdits && (isNewEntry && isEmpty).not())
+    val editsWereMade = (hasUserEdits && (isNewEntry && isEmpty).not() /*no edits if it is a new entry and is empty*/ )
 
 
 }

--- a/app/src/main/java/journal/gratitude/com/gratitudejournal/ui/entry/EntryState.kt
+++ b/app/src/main/java/journal/gratitude/com/gratitudejournal/ui/entry/EntryState.kt
@@ -47,5 +47,7 @@ data class EntryState(
     )
 
     val isEmpty = entryContent.isEmpty()
+    val editsWereMade = (hasUserEdits || (isNewEntry && isEmpty).not())
+
 
 }

--- a/app/src/main/java/journal/gratitude/com/gratitudejournal/ui/entry/EntryState.kt
+++ b/app/src/main/java/journal/gratitude/com/gratitudejournal/ui/entry/EntryState.kt
@@ -48,6 +48,4 @@ data class EntryState(
 
     val isEmpty = entryContent.isEmpty()
 
-    val editsWereMade=(hasUserEdits && !isEmpty)
-
 }

--- a/app/src/main/java/journal/gratitude/com/gratitudejournal/ui/entry/EntryViewModel.kt
+++ b/app/src/main/java/journal/gratitude/com/gratitudejournal/ui/entry/EntryViewModel.kt
@@ -33,6 +33,8 @@ class EntryViewModel @AssistedInject constructor(
                     setState {
                         copy(entryContent = entry.entryContent)
                     }
+                } else {
+                    setState { copy(entryContent = "", hasUserEdits = false) }
                 }
             }
         }
@@ -57,7 +59,7 @@ class EntryViewModel @AssistedInject constructor(
                 setState {
                     copy(entryContent = newText, hasUserEdits = true)
                 }
-            }else{
+            } else {
                 setState {
                     copy(entryContent = newText, hasUserEdits = false)
                 }

--- a/app/src/test/java/journal/gratitude/com/gratitudejournal/ui/entry/EntryViewModelTest.kt
+++ b/app/src/test/java/journal/gratitude/com/gratitudejournal/ui/entry/EntryViewModelTest.kt
@@ -115,7 +115,7 @@ class EntryViewModelTest {
         withState(viewModel) {
             assertEquals(it.entryContent, "new text")
             assertEquals(it.hasUserEdits, true)
-            assertEquals(it.hasUserEdits, true)
+            assertEquals(it.editsWereMade, true)
         }
     }
 
@@ -139,6 +139,7 @@ class EntryViewModelTest {
         withState(viewModel) {
             assertEquals(it.entryContent, "")
             assertEquals(it.hasUserEdits, true)
+            assertEquals(it.editsWereMade, false)
         }
     }
 
@@ -361,7 +362,7 @@ class EntryViewModelTest {
             assertThat(it.promptsList).isEqualTo(listOf("one", "two", "three"))
             assertThat(it.isSaved).isFalse()
             assertThat(it.milestoneNumber).isEqualTo(0)
-            assertThat(it.hasUserEdits).isFalse()
+            assertThat(it.editsWereMade).isFalse()
         }
     }
 
@@ -398,6 +399,7 @@ class EntryViewModelTest {
             assertThat(it.promptsList).isEqualTo(listOf("one", "two", "three"))
             assertThat(it.isSaved).isFalse()
             assertThat(it.milestoneNumber).isEqualTo(0)
+            assertThat(it.editsWereMade).isFalse()
         }
     }
 
@@ -438,7 +440,7 @@ class EntryViewModelTest {
 
         withState(viewModel) {
             assertThat(it.entryContent).isEqualTo("")
-            assertThat(it.hasUserEdits).isFalse()
+            assertThat(it.editsWereMade).isFalse()
         }
 
     }

--- a/app/src/test/java/journal/gratitude/com/gratitudejournal/ui/entry/EntryViewModelTest.kt
+++ b/app/src/test/java/journal/gratitude/com/gratitudejournal/ui/entry/EntryViewModelTest.kt
@@ -115,7 +115,7 @@ class EntryViewModelTest {
         withState(viewModel) {
             assertEquals(it.entryContent, "new text")
             assertEquals(it.hasUserEdits, true)
-            assertEquals(it.editsWereMade, true)
+            assertEquals(it.hasUserEdits, true)
         }
     }
 
@@ -123,7 +123,7 @@ class EntryViewModelTest {
     fun `GIVEN entry view model WHEN text is cleared THEN the state is updated`() {
         val initialState = EntryState(
             LocalDate.now(),
-            "",
+            "This is an entry",
             true,
             null,
             "hint",
@@ -139,7 +139,6 @@ class EntryViewModelTest {
         withState(viewModel) {
             assertEquals(it.entryContent, "")
             assertEquals(it.hasUserEdits, true)
-            assertEquals(it.editsWereMade, false)
         }
     }
 
@@ -362,7 +361,7 @@ class EntryViewModelTest {
             assertThat(it.promptsList).isEqualTo(listOf("one", "two", "three"))
             assertThat(it.isSaved).isFalse()
             assertThat(it.milestoneNumber).isEqualTo(0)
-            assertThat(it.editsWereMade).isFalse()
+            assertThat(it.hasUserEdits).isFalse()
         }
     }
 
@@ -389,7 +388,7 @@ class EntryViewModelTest {
 
         withState(viewModel) {
             assertThat(it.date).isEqualTo(LocalDate.now())
-            assertThat(it.entryContent).isEqualTo(" ")
+            assertThat(it.entryContent).isEqualTo("")
             assertThat(it.isNewEntry).isFalse()
             assertThat(it.numberExistingEntries).isEqualTo(0)
             assertThat(it.hint).isEqualTo("What are you grateful for?")
@@ -399,7 +398,48 @@ class EntryViewModelTest {
             assertThat(it.promptsList).isEqualTo(listOf("one", "two", "three"))
             assertThat(it.isSaved).isFalse()
             assertThat(it.milestoneNumber).isEqualTo(0)
-            assertThat(it.editsWereMade).isFalse()
         }
+    }
+
+    @Test
+    fun `GIVEN new entry When text is set and reset then state should be updated`() {
+        val entryArgs = EntryArgs(LocalDate.now().toString(), true, 0, "Quote", "What are you grateful for?", listOf("one", "two", "three"))
+        val initialState = EntryState(entryArgs)
+        val repository = object : EntryRepository {
+            override suspend fun getEntry(date: LocalDate): Entry? = null
+
+            override suspend fun getEntriesFlow(): Flow<List<Entry>> = emptyFlow()
+
+            override suspend fun getEntries(): List<Entry> = emptyList()
+
+            override fun getWrittenDates(): LiveData<List<LocalDate>> = MutableLiveData(emptyList())
+
+            override suspend fun addEntry(entry: Entry) {}
+
+            override suspend fun addEntries(entries: List<Entry>) = Unit
+
+            override fun searchEntries(query: String): Flow<PagingData<Entry>> = flowOf(PagingData.empty())
+        }
+        viewModel = EntryViewModel(initialState, analytics, repository)
+
+        withState(viewModel) {
+            assertThat(it.entryContent).isEqualTo("")
+            assertThat(it.hasUserEdits).isFalse()
+        }
+
+        viewModel.onTextChanged("I am grateful for each and everything")
+
+        withState(viewModel) {
+            assertThat(it.entryContent).isEqualTo("I am grateful for each and everything")
+            assertThat(it.hasUserEdits).isTrue()
+        }
+
+        viewModel.getEntry()
+
+        withState(viewModel) {
+            assertThat(it.entryContent).isEqualTo("")
+            assertThat(it.hasUserEdits).isFalse()
+        }
+
     }
 }


### PR DESCRIPTION
## :scroll: Description
<!-- Describe your changes in detail, add links to issue/ticket -->
As video added there: https://github.com/alisonthemonster/Presently/pull/261#issuecomment-1280491924 whenever we create a new entry and put something. When we press back the dialog shows to either continue or Cancel. When Continue is clicked, it should dismiss the dialog with entry page and should show the TimeLine Screen but it stuck in a cycle. It is related to https://github.com/alisonthemonster/Presently/pull/261

## :green_heart: How did you test it?
<!-- Unit, Integration, Manual? If manual, how was it tested? -->

- [x] User click on Today date and then enter something. Confirm dialog is shown and user is able to navigate between Today and Yesterday dates
- [x] User selects date from calendar then then try to swipe between entries
- [x] User should not see confirm dialog incase of navigating back from new entry
- [x] Confirm dialog is not shown while navigating between entries with no edits

## :camera_flash: Screenshots / GIFs
<!-- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->

<!-- <img src="https://user-images.githubusercontent.com/883468/93824506-8ef15880-fc31-11ea-9f44-ca32bb0de88a.jpg" width="260"/> -->



https://user-images.githubusercontent.com/33172684/196183973-6cb730b6-daca-481e-9b2c-57128de3ac87.mp4


https://user-images.githubusercontent.com/33172684/196184009-05d44444-1aa3-4699-9e92-fb1b9df3ed51.mp4

