### PR TITLE
Fix Issue: Languages text not visible on 'Emilia' theme #269

### DIFF
--- a/app/src/main/java/journal/gratitude/com/gratitudejournal/ui/settings/CustomListPrefDialogFragCompat.kt
+++ b/app/src/main/java/journal/gratitude/com/gratitudejournal/ui/settings/CustomListPrefDialogFragCompat.kt
@@ -33,7 +33,7 @@ class CustomListPrefDialogFragCompat: ListPreferenceDialogFragmentCompat() {
         val theme = context?.theme
         val attrs = IntArray(3)
         attrs[0] = R.attr.timelineBackgroundColor
-        attrs[1] = R.attr.entryBodyColor
+        attrs[1] = R.attr.timelineBodyColor
         val typedArray = theme?.obtainStyledAttributes(attrs)
 
         val backgroundColor  = typedArray?.getColor(0, Color.WHITE)

--- a/ui/src/main/res/values/styles.xml
+++ b/ui/src/main/res/values/styles.xml
@@ -10,9 +10,9 @@
         <!-- CHANGES THE DIALOG BACKGROUND COLOR!       -->
         <item name="android:colorBackground">?attr/timelineBackgroundColor</item>
         <!-- CHANGES BODY TEXT COLOR IN DIALOGS BUT NOT IN TIME PICKER     -->
-        <item name="android:textColorPrimary">?attr/entryBodyColor</item>
+        <item name="android:textColorPrimary">?attr/timelineBodyColor</item>
         <!-- CHANGES HEADER TEXT COLOR IN DIALOGS BUT NOT IN TIME PICKER     -->
-        <item name="android:textColor">?attr/entryBodyColor</item>
+        <item name="android:textColor">?attr/timelineBodyColor</item>
     </style>
 
     <style name="NegativeButtonStyle" parent="Widget.MaterialComponents.Button.TextButton.Dialog">
@@ -20,7 +20,7 @@
     </style>
 
     <style name="PositiveButtonStyle" parent="Widget.MaterialComponents.Button.TextButton.Dialog">
-        <item name="android:textColor">?attr/entryBodyColor</item>
+        <item name="android:textColor">?attr/timelineBodyColor</item>
     </style>
 
     <style name="TextAppearance.Title" parent="Theme.MaterialComponents.Light.NoActionBar">


### PR DESCRIPTION
## :scroll: Description
Fix for [this issue](https://github.com/alisonthemonster/Presently/issues/269) #269 where the languages text is not visible in 'Emilia' theme. 

Added fix for [this issue](https://github.com/alisonthemonster/Presently/issues/271) #271 where Import CSV Alert Dialog test is not visible in 'Emilia' theme.

To contrast against the background colour for the language menu set by 'timelineBackgroundColor', I have aligned the text colour to use 'timelineBodyColor' from the the active theme for the language menu, instead of 'entryBodyColor'. 

This involves an edit to [CustomListPrefDialogFragCompat.kt](https://github.com/alisonthemonster/Presently/compare/develop...anettleship:Presently:AlignSettingsColor#diff-40b1ff58c8c59deea855b46e8a00f21e9675bd4f88bab6ef75961cfe9cae3446)

This also fixes the same text issue which is present in the First Day of the Week dialog (see screenshots).

I've added a second edit to address the [issue with the Import CSV Alert Dialog](https://github.com/alisonthemonster/Presently/issues/271), making changes to [styles.xml](https://github.com/anettleship/Presently/blob/AlignSettingsColor/ui/src/main/res/values/styles.xml#L7) where the AlertDialogTheme is set, again changing 'entryBodyColor' to 'timelineBodyColor' for the textColorPrimary and textColor Values, as well as the PositiveButtonStyle defined in the same section.


## :green_heart: How did you test it?
Manual test in Android Studio Emulator and on a Physical Pixel 6a. 

Value comparison of the colour numbers set for 'entryBodyColor' and 'timelineBodyColor' in each theme in [colors.xml](https://github.com/alisonthemonster/Presently/blob/develop/ui/src/main/res/values/colors.xml).

The only theme affected other than Emilia, is Calm, which has very slightly different shades of text set by 'entryBodyColor' and 'timelineBodyColor'. See screenshots below.



## :camera_flash: Screenshots / GIFs

Emilia Before:
![Screenshot_20230123-211930](https://user-images.githubusercontent.com/5358837/214154942-44dd3a56-f4fe-4508-acd7-3ae9f5e8a58e.png)

Emilia After:
![Screenshot_20230123-211753](https://user-images.githubusercontent.com/5358837/214154940-18f57412-3432-402c-95d5-2fa0a72948df.png)

Calm Before:
![Screenshot_20230123-212448](https://user-images.githubusercontent.com/5358837/214154932-b4779f66-449e-4f5f-a96c-708c0a56f934.png)

Calm After:
![Screenshot_20230123-212655](https://user-images.githubusercontent.com/5358837/214154937-3416227c-c61e-41bf-bee8-c59488265fcf.png)

Betsy Before (No Change):
![Screenshot_20230123-211939](https://user-images.githubusercontent.com/5358837/214156693-67ce7f59-6d07-4d68-890c-3a48089cbb1e.png)

Betsy After (No Change):
![Screenshot_20230123-211807](https://user-images.githubusercontent.com/5358837/214156869-b0781040-f63f-465a-8a61-d1122b58f896.png)

Emilia First Day of the Week, Before:
![Screenshot_20230123-215009](https://user-images.githubusercontent.com/5358837/214158584-8548392b-cf32-4d30-bb3a-145cde2d4147.png)

Emilia First Day of the Week, After:
![Screenshot_20230123-215053](https://user-images.githubusercontent.com/5358837/214158632-1010c994-ff62-4893-9cd3-8813f7a4cd85.png)

Emilia Import Dialogue Before:
![Screenshot_20230124-213501 Emilia Before](https://user-images.githubusercontent.com/5358837/214427507-285077d1-92ec-46c2-891f-6e83379519a8.png)

Emilia Import Dialogue After:
![Screenshot_20230124-212913 Emilia After](https://user-images.githubusercontent.com/5358837/214427400-3588c63d-6c14-4783-b680-e663f34e02f1.png)

Calm Import Dialogue Before:
![Screenshot_20230124-213535 Calm Before](https://user-images.githubusercontent.com/5358837/214427309-d5c19f43-a11d-46ce-b844-94863b0f737d.png)

Calm Import Dialogue After:
![Screenshot_20230124-213330 Calm After](https://user-images.githubusercontent.com/5358837/214427328-7d9226ac-c113-4745-a8d6-298976a9bf86.png)

Betsy Import Dialogue Before (No Change):
![Screenshot_20230124-213547 Betsy Before](https://user-images.githubusercontent.com/5358837/214427350-3fa074ab-b6fc-4411-8850-ed652671d6b6.png)

Betsy Import Dialogue After (No Change):
![Screenshot_20230124-214044 Betsy After](https://user-images.githubusercontent.com/5358837/214427368-b8a8a85d-a779-4ea2-aff8-45d77bcb1f42.png)


