### PR TITLE
Remove AD_ID permission from merged manifest

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,9 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission
+        android:name="com.google.android.gms.permission.AD_ID"
+        tools:node="remove" />
 
     <application
         android:name=".GratitudeApplication"


### PR DESCRIPTION
## :scroll: Description
When trying to upload to the Play Console I encountered this message:
```
Your app targets Android 13 (API 33) or above. You must declare the use of advertising ID in Play Console.
```

Likely a dependency was bringing this is in. We have this already in our manifest:
```
<meta-data
            android:name="google_analytics_adid_collection_enabled"
            android:value="false" />
```
so this just ensures we don't request the permission. 