### PR TITLE
Jump to latest Dropbox version and bump minsdk

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -211,7 +211,8 @@ dependencies {
     implementation(Libraries.material)
     implementation(Libraries.play_services_oss_licenses)
     implementation(Libraries.compact_calendar_view)
-    implementation(Libraries.dropbox_sdk)
+    implementation(Libraries.dropbox_core_sdk)
+    implementation(Libraries.dropbox_android_sdk)
     implementation(Libraries.apache_text)
     implementation(Libraries.apache_csv)
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,6 +18,7 @@
         android:theme="@style/AppTheme">
         <activity
             android:name=".ContainerActivity"
+            android:launchMode="singleTask"
             android:windowSoftInputMode="adjustResize"
             android:exported="true">
             <intent-filter>
@@ -35,6 +36,10 @@
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.BROWSABLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </activity>

--- a/app/src/main/java/journal/gratitude/com/gratitudejournal/ContainerActivity.kt
+++ b/app/src/main/java/journal/gratitude/com/gratitudejournal/ContainerActivity.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Context
+import android.content.Intent
 import android.content.res.Configuration
 import android.os.Build
 import android.os.Bundle
@@ -68,6 +69,11 @@ class ContainerActivity : AppCompatActivity() {
     override fun onResume() {
         super.onResume()
         isGooglePlayServicesAvailable(this)
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
     }
 
     private fun isGooglePlayServicesAvailable(activity: Activity): Boolean {

--- a/app/src/main/java/journal/gratitude/com/gratitudejournal/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/journal/gratitude/com/gratitudejournal/ui/settings/SettingsFragment.kt
@@ -29,6 +29,7 @@ import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import com.dropbox.core.android.Auth
+import com.dropbox.core.android.AuthActivity
 import com.google.android.gms.oss.licenses.OssLicensesMenuActivity
 import com.google.android.material.snackbar.Snackbar
 import journal.gratitude.com.gratitudejournal.logging.AnalyticsLogger
@@ -162,7 +163,23 @@ class SettingsFragment : PreferenceFragmentCompat(),
                 }
             } else {
                 analytics.recordEvent(DROPBOX_AUTH_ATTEMPT)
-                DropboxUploader.authorizeDropboxAccess(requireContext(), settings)
+                try {
+                    val appKey = BuildConfig.DROPBOX_APP_KEY
+                    val manifestCheckPassed =
+                        AuthActivity.checkAppBeforeAuth(requireContext(), appKey, false)
+                    if (!manifestCheckPassed) {
+                        val exception = IllegalStateException(
+                            "Dropbox manifest/auth precheck failed before auth start"
+                        )
+                        crashReporter.logHandledException(exception)
+                        Toast.makeText(context, R.string.dropbox_auth_failed, Toast.LENGTH_SHORT).show()
+                        return@setOnPreferenceClickListener true
+                    }
+                    DropboxUploader.authorizeDropboxAccess(requireContext(), settings)
+                } catch (exception: Exception) {
+                    crashReporter.logHandledException(exception)
+                    Toast.makeText(context, R.string.dropbox_auth_failed, Toast.LENGTH_SHORT).show()
+                }
             }
             true
         }
@@ -204,11 +221,16 @@ class SettingsFragment : PreferenceFragmentCompat(),
             val token = Auth.getDbxCredential() //get token from Dropbox Auth activity
             if (token == null) {
                 //user started to auth and didn't succeed
+                val exception = IllegalStateException(
+                    "Dropbox auth resumed without a credential. data=${activity?.intent?.data}"
+                )
+                crashReporter.logHandledException(exception)
                 settings.markDropboxAuthAsCancelled()
+                Toast.makeText(context, R.string.dropbox_auth_failed, Toast.LENGTH_SHORT).show()
                 activity?.recreate()
             } else {
                 settings.setAccessToken(token)
-                createDropboxUploaderWorker(BackupCadence.DAILY)
+                createDropboxUploaderWorker(settings.getAutomaticBackupCadence())
                 cancelDropboxFailureNotifications() //now that user has auth'd cancel any notifs about previous failure
             }
         }

--- a/app/src/main/res/values-af/presently_strings.xml
+++ b/app/src/main/res/values-af/presently_strings.xml
@@ -115,5 +115,6 @@
     <string name="backup_failure_notif_header">Presently outomatiese rugsteun mislukking</string>
     <string name="dropbox_too_full_notif_body">Presently kon nie jou data rugsteun nie omdat jou Dropbox vol is. Tik om jou Dropbox-rekening te sien.</string>
     <string name="dropbox_sync_error_notif_body">Daar was \'n probleem met jou Dropbox-rekening, klik hier om weer aan Dropbox te koppel om outomatiese rugsteun te hervat.</string>
+    <string name="dropbox_auth_failed">Kon nie Dropbox-rekening koppel nie</string>
     <string name="learn_more">Leer meer</string>
 </resources>

--- a/app/src/main/res/values-ar/presently_strings.xml
+++ b/app/src/main/res/values-ar/presently_strings.xml
@@ -115,5 +115,6 @@
     <string name="backup_failure_notif_header">فشل النسخ الاحتياطي التلقائي</string>
     <string name="dropbox_too_full_notif_body">فشل التطبيق في الاحتفاظ بنسخة احتياطية من بياناتك لأن Dropbox الخاص بك ممتلئ. انقر لعرض حساب Dropbox الخاص بك</string>
     <string name="dropbox_sync_error_notif_body">كانت هناك مشكلة في حساب Dropbox الخاص بك ، انقر هنا لإعادة الاتصال بـ Dropbox لاستئناف النسخ الاحتياطية التلقائية.</string>
+    <string name="dropbox_auth_failed">حدث خطأ أثناء ربط حساب Dropbox</string>
     <string name="learn_more">يتعلم أكثر</string>
 </resources>

--- a/app/src/main/res/values-de/presently_strings.xml
+++ b/app/src/main/res/values-de/presently_strings.xml
@@ -113,5 +113,6 @@
     <string name="backup_failure_notif_header">Presently Automatisches Backup fehlgeschlagen</string>
     <string name="dropbox_too_full_notif_body">Presently konnte Ihre Daten nicht sichern, da Ihre Dropbox voll ist. Tippen Sie hier, um Ihr Dropbox-Konto anzuzeigen.</string>
     <string name="dropbox_sync_error_notif_body">Es ist ein Problem mit Ihrem Dropbox-Konto aufgetreten. Klicken Sie hier, um sich erneut mit Dropbox zu verbinden und die automatischen Backups fortzusetzen.</string>
+    <string name="dropbox_auth_failed">Fehler beim Verknüpfen des Dropbox-Kontos</string>
     <string name="learn_more">Mehr erfahren</string>
 </resources>

--- a/app/src/main/res/values-es/presently_strings.xml
+++ b/app/src/main/res/values-es/presently_strings.xml
@@ -115,5 +115,6 @@
     <string name="backup_failure_notif_header">Fallo de copia de respaldo automático de Presently</string>
     <string name="dropbox_too_full_notif_body">Presently no pudo hacer una copia de respaldo de sus datos porque su Dropbox está lleno. Toque para ver su cuenta de Dropbox</string>
     <string name="dropbox_sync_error_notif_body">Hubo un problema con su cuenta de Dropbox, haga clic aquí para volver a conectarse a Dropbox y reanudar las copias de respaldo automáticos.</string>
+    <string name="dropbox_auth_failed">Error al vincular la cuenta de Dropbox</string>
     <string name="learn_more">Aprende más</string>
 </resources>

--- a/app/src/main/res/values-fi/presently_strings.xml
+++ b/app/src/main/res/values-fi/presently_strings.xml
@@ -114,5 +114,6 @@
     <string name="backup_failure_notif_header">Presentlhin automaattinen varmuuskopiointivirhe</string>
     <string name="dropbox_too_full_notif_body">Presentlhin ei pystynyt varmuuskopioimaan tietojasi, koska Dropboxisi on täynnä. Napauta nähdäksesi Dropbox-tilisi</string>
     <string name="dropbox_sync_error_notif_body">Dropbox-tililläsi oli ongelma. Napsauta tätä yhdistääksesi uudelleen Dropboxiin jatkaaksesi automaattista varmuuskopiointia.</string>
+    <string name="dropbox_auth_failed">Virhe yhdistettäessä Dropbox-tiliä</string>
     <string name="learn_more">Lue lisää</string>
 </resources>

--- a/app/src/main/res/values-fr/presently_strings.xml
+++ b/app/src/main/res/values-fr/presently_strings.xml
@@ -114,5 +114,6 @@
     <string name="backup_failure_notif_header">Échec de la sauvegarde automatique de Presently</string>
     <string name="dropbox_too_full_notif_body">Presently n\'a pas réussi à sauvegarder vos données car votre Dropbox est pleine. Appuyez pour afficher votre compte Dropbox</string>
     <string name="dropbox_sync_error_notif_body">Il y a eu un problème avec votre compte Dropbox, cliquez ici pour vous reconnecter à Dropbox et reprendre les sauvegardes automatiques.</string>
+    <string name="dropbox_auth_failed">Erreur lors de la liaison du compte Dropbox</string>
     <string name="learn_more">Apprendre encore plus</string>
 </resources>

--- a/app/src/main/res/values-hr/presently_strings.xml
+++ b/app/src/main/res/values-hr/presently_strings.xml
@@ -113,5 +113,6 @@
     <string name="backup_failure_notif_header">Presently automatikus biztonsági mentési hiba</string>
     <string name="dropbox_too_full_notif_body">Presently nem sikerült biztonsági másolatot készítenie az adatokról, mert a Dropbox megtelt. Érintse meg a Dropbox-fiók megtekintéséhez</string>
     <string name="dropbox_sync_error_notif_body">Probléma lépett fel a Dropbox-fiókjával. Kattintson ide, hogy újra csatlakozzon a Dropboxhoz az automatikus biztonsági mentések folytatásához.</string>
+    <string name="dropbox_auth_failed">Pogreška pri povezivanju Dropbox računa</string>
     <string name="learn_more">Tudj meg többet</string>
 </resources>

--- a/app/src/main/res/values-it/presently_strings.xml
+++ b/app/src/main/res/values-it/presently_strings.xml
@@ -114,5 +114,6 @@
     <string name="backup_failure_notif_header">Errore di backup automatico di Presently</string>
     <string name="dropbox_too_full_notif_body">Presently non è riuscita a eseguire il backup dei tuoi dati perché il tuo Dropbox è pieno. Tocca per visualizzare il tuo account Dropbox</string>
     <string name="dropbox_sync_error_notif_body">Si è verificato un problema con il tuo account Dropbox, fai clic qui per riconnetterti a Dropbox e riprendere i backup automatici.</string>
+    <string name="dropbox_auth_failed">Errore durante il collegamento dell\'account Dropbox</string>
     <string name="learn_more">Scopri di più</string>
 </resources>

--- a/app/src/main/res/values-nl/presently_strings.xml
+++ b/app/src/main/res/values-nl/presently_strings.xml
@@ -112,5 +112,6 @@
     <string name="backup_failure_notif_header">Automatische back-up van Presently mislukt</string>
     <string name="dropbox_too_full_notif_body">Presently kan geen back-up van je gegevens maken omdat je Dropbox vol is. Tik om je Dropbox-account te bekijken</string>
     <string name="dropbox_sync_error_notif_body">Er was een probleem met je Dropbox-account. Klik hier om opnieuw verbinding te maken met Dropbox om de automatische back-ups te hervatten.</string>
+    <string name="dropbox_auth_failed">Fout bij koppelen van Dropbox-account</string>
     <string name="learn_more">Leer meer</string>
 </resources>

--- a/app/src/main/res/values-pl/presently_strings.xml
+++ b/app/src/main/res/values-pl/presently_strings.xml
@@ -112,5 +112,6 @@
     <string name="backup_failure_notif_header">Awaria automatycznej kopii zapasowej Presently</string>
     <string name="dropbox_too_full_notif_body">Presently nie utworzyła kopii zapasowej Twoich danych, ponieważ Twój Dropbox jest pełny. Dotknij, aby wyświetlić swoje konto Dropbox</string>
     <string name="dropbox_sync_error_notif_body">Wystąpił problem z Twoim kontem Dropbox. Kliknij tutaj, aby ponownie połączyć się z Dropbox i wznowić automatyczne tworzenie kopii zapasowych.</string>
+    <string name="dropbox_auth_failed">Błąd podczas łączenia konta Dropbox</string>
     <string name="learn_more">Ucz się więcej</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/presently_strings.xml
+++ b/app/src/main/res/values-pt-rBR/presently_strings.xml
@@ -113,5 +113,6 @@
     <string name="backup_failure_notif_header">Falha de backup automático de Presently</string>
     <string name="dropbox_too_full_notif_body">Presently não conseguiu fazer backup de seus dados porque seu Dropbox está cheio. Toque para ver sua conta do Dropbox</string>
     <string name="dropbox_sync_error_notif_body">Ocorreu um problema com sua conta do Dropbox, clique aqui para se reconectar ao Dropbox e retomar os backups automáticos.</string>
+    <string name="dropbox_auth_failed">Erro ao vincular a conta do Dropbox</string>
     <string name="learn_more">Saber mais</string>
 </resources>

--- a/app/src/main/res/values-pt/presently_strings.xml
+++ b/app/src/main/res/values-pt/presently_strings.xml
@@ -114,5 +114,6 @@
     <string name="backup_failure_notif_header">Falha de backup automático de Presently</string>
     <string name="dropbox_too_full_notif_body">Presently não conseguiu fazer backup de seus dados porque seu Dropbox está cheio. Toque para ver sua conta do Dropbox</string>
     <string name="dropbox_sync_error_notif_body">Ocorreu um problema com sua conta do Dropbox, clique aqui para se reconectar ao Dropbox e retomar os backups automáticos.</string>
+    <string name="dropbox_auth_failed">Erro ao ligar a conta Dropbox</string>
     <string name="learn_more">Saber mais</string>
 </resources>

--- a/app/src/main/res/values-ro/presently_strings.xml
+++ b/app/src/main/res/values-ro/presently_strings.xml
@@ -115,5 +115,6 @@
     <string name="backup_failure_notif_header">Eroare de backup automat Presently</string>
     <string name="dropbox_too_full_notif_body">Presently nu a reușit să vă copieze datele deoarece Dropbox-ul este plin. Atingeți pentru a vedea contul dvs. Dropbox.</string>
     <string name="dropbox_sync_error_notif_body">A apărut o problemă cu contul dvs. Dropbox, faceți clic aici pentru a vă reconecta la Dropbox pentru a relua backup-urile automate.</string>
+    <string name="dropbox_auth_failed">Eroare la conectarea contului Dropbox</string>
     <string name="learn_more">Află mai multe</string>
 </resources>

--- a/app/src/main/res/values-ru/presently_strings.xml
+++ b/app/src/main/res/values-ru/presently_strings.xml
@@ -114,5 +114,6 @@
     <string name="backup_failure_notif_header">Ошибка автоматического резервного копирования Presently</string>
     <string name="dropbox_too_full_notif_body">Presently не удалось создать резервную копию ваших данных, потому что ваш Dropbox заполнен. Нажмите, чтобы просмотреть свою учетную запись Dropbox.</string>
     <string name="dropbox_sync_error_notif_body">Возникла проблема с вашей учетной записью Dropbox. Нажмите здесь, чтобы повторно подключиться к Dropbox и возобновить автоматическое резервное копирование.</string>
+    <string name="dropbox_auth_failed">Ошибка при подключении аккаунта Dropbox</string>
     <string name="learn_more">Выучить больше</string>
 </resources>

--- a/app/src/main/res/values-sk/presently_strings.xml
+++ b/app/src/main/res/values-sk/presently_strings.xml
@@ -115,5 +115,6 @@
     <string name="backup_failure_notif_header">Presently zlyhalo automatické zálohovanie</string>
     <string name="dropbox_too_full_notif_body">Presently zlyhala pri zálohovaní vašich údajov, pretože váš Dropbox je plný. Klepnutím zobrazíte svoj účet Dropbox</string>
     <string name="dropbox_sync_error_notif_body">Vyskytol sa problém s vaším účtom Dropbox. Kliknutím sem sa znova pripojte k Dropboxu a obnovte automatické zálohovanie.</string>
+    <string name="dropbox_auth_failed">Chyba pri prepájaní účtu Dropbox</string>
     <string name="learn_more">Uč sa viac</string>
 </resources>

--- a/app/src/main/res/values-tr/presently_strings.xml
+++ b/app/src/main/res/values-tr/presently_strings.xml
@@ -115,5 +115,6 @@
     <string name="backup_failure_notif_header">Presently Otomatik Yedekleme Hatası</string>
     <string name="dropbox_too_full_notif_body">Presently, Dropbox\'ınız dolu olduğu için verilerinizi yedekleyemedi. Dropbox hesabınızı görüntülemek için dokunun</string>
     <string name="dropbox_sync_error_notif_body">Dropbox hesabınızla ilgili bir sorun oluştu, otomatik yedeklemeleri sürdürmek üzere Dropbox\'a yeniden bağlanmak için burayı tıklayın.</string>
+    <string name="dropbox_auth_failed">Dropbox hesabı bağlanırken hata oluştu</string>
     <string name="learn_more">Daha fazla bilgi edin</string>
 </resources>

--- a/app/src/main/res/values-zh-rHK/presently_strings.xml
+++ b/app/src/main/res/values-zh-rHK/presently_strings.xml
@@ -113,5 +113,6 @@
     <string name="backup_failure_notif_header">Presently 自动备份失败</string>
     <string name="dropbox_too_full_notif_body">Presently 未能备份您的数据，因为您的 Dropbox 已满。 点按即可查看您的 Dropbox 帐户</string>
     <string name="dropbox_sync_error_notif_body">您的 Dropbox 帐户出现问题，请单击此处重新连接到 Dropbox 以恢复自动备份。</string>
+    <string name="dropbox_auth_failed">連結 Dropbox 帳戶時發生錯誤</string>
     <string name="learn_more">学到更多</string>
 </resources>

--- a/app/src/main/res/values/presently_strings.xml
+++ b/app/src/main/res/values/presently_strings.xml
@@ -116,5 +116,6 @@
     <string name="backup_failure_notif_header">Presently Automatic Backup Failure</string>
     <string name="dropbox_too_full_notif_body">Presently failed to backup your data because your Dropbox is full. Tap to view your Dropbox account.</string>
     <string name="dropbox_sync_error_notif_body">There was a problem with your Dropbox account, click here to reconnect to Dropbox to resume automatic backups.</string>
+    <string name="dropbox_auth_failed">Error linking Dropbox account</string>
     <string name="learn_more">Learn more</string>
 </resources>

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -1,7 +1,7 @@
 object Versions {
     const val COMPILE_SDK = 35
     const val TARGET_SDK = 35
-    const val MIN_SDK = 23
+    const val MIN_SDK = 26
 
     const val APP_VERSION_CODE = 91
 
@@ -35,7 +35,7 @@ object Versions {
     const val DAGGER = "2.57.2"
     const val HILT_ANDROID = "1.3.0"
     const val JUNIT = "4.13.2"
-    const val DROPBOX_SDK = "5.1.1" //https://github.com/dropbox/dropbox-sdk-java/releases
+    const val DROPBOX_SDK = "7.0.0" //https://github.com/dropbox/dropbox-sdk-java/releases
     const val PLAY_CORE = "2.1.0"
     const val MOCKITO_KOTLIN = "2.0.0"
     const val MOCKITO_ANDROID = "2.23.0"
@@ -89,7 +89,8 @@ object Libraries {
    const val androidx_room_compiler = "androidx.room:room-compiler:${Versions.ANDROIDX_ROOM}"
    const val androidx_room_paging = "androidx.room:room-paging:${Versions.ANDROIDX_ROOM}"
    const val three_ten_abp = "com.jakewharton.threetenabp:threetenabp:${Versions.THREE_TEN_ABP}"
-   const val dropbox_sdk = "com.dropbox.core:dropbox-core-sdk:${Versions.DROPBOX_SDK}"
+   const val dropbox_core_sdk = "com.dropbox.core:dropbox-core-sdk:${Versions.DROPBOX_SDK}"
+   const val dropbox_android_sdk = "com.dropbox.core:dropbox-android-sdk:${Versions.DROPBOX_SDK}"
    const val play_core = "com.google.android.play:feature-delivery:${Versions.PLAY_CORE}"
    const val material = "com.google.android.material:material:${Versions.MATERIAL}"
    const val play_services_oss_licenses = "com.google.android.gms:play-services-oss-licenses:${Versions.OSS_LICENSES}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,4 +15,5 @@ org.gradle.jvmargs=-Xmx2048m
 kotlin.code.style=official
 android.useAndroidX=true
 android.enableJetifier=true
+android.jetifier.ignorelist=jackson-core,fastdoubleparser
 android.nonTransitiveRClass=false


### PR DESCRIPTION
## :scroll: Description
To have Dropbox automatic backup work we had to update the SDK version (note from Dropbox [here](https://dropbox.tech/developers/api-server-certificate-changes)). Because of this bump we also had to bump the `minSdk` to 26. 

Also silent auth-return failures are reported to Crashlytics and an error message toast will be shown to users if auth to Dropbox fails.
