### PR TITLE
Status bar color fix

### DIFF
--- a/app/src/main/java/journal/gratitude/com/gratitudejournal/ui/search/SearchScreen.kt
+++ b/app/src/main/java/journal/gratitude/com/gratitudejournal/ui/search/SearchScreen.kt
@@ -6,14 +6,13 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -118,13 +117,14 @@ fun SearchScreenContent(
         modifier = Modifier
             .fillMaxSize()
             .background(theme.timelineBackground)
-            .windowInsetsPadding(WindowInsets.safeDrawing)
+            .navigationBarsPadding()
             .imePadding()
     ) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
                 .background(theme.toolbar)
+                .statusBarsPadding()
                 .padding(horizontal = 8.dp, vertical = 8.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {

--- a/app/src/main/java/journal/gratitude/com/gratitudejournal/ui/timeline/TimelineFragment.kt
+++ b/app/src/main/java/journal/gratitude/com/gratitudejournal/ui/timeline/TimelineFragment.kt
@@ -15,6 +15,7 @@ import androidx.activity.OnBackPressedCallback
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isVisible
+import androidx.core.view.updateLayoutParams
 import androidx.core.view.updatePadding
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
@@ -166,11 +167,17 @@ class TimelineFragment : Fragment() {
             animation.openCalendar()
         }
 
+        val titleTopMargin =
+            (binding.title.layoutParams as ViewGroup.MarginLayoutParams).topMargin
+
         ViewCompat.setOnApplyWindowInsetsListener(view) { v, insets ->
+            val statusBarTopInset = insets.getInsets(WindowInsetsCompat.Type.statusBars()).top
             v.updatePadding(
-                top = insets.getInsets(WindowInsetsCompat.Type.statusBars()).top,
                 bottom = insets.getInsets(WindowInsetsCompat.Type.navigationBars()).bottom
             )
+            binding.title.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+                topMargin = titleTopMargin + statusBarTopInset
+            }
             insets
         }
 
@@ -257,4 +264,3 @@ class TimelineFragment : Fragment() {
         const val TIMELINE_TO_SETTINGS = "TIMELINE_TO_ENTRY"
     }
 }
-

--- a/app/src/main/res/layout/timeline_fragment.xml
+++ b/app/src/main/res/layout/timeline_fragment.xml
@@ -41,7 +41,7 @@
         android:transitionName="search_transition"
         app:layout_constraintBottom_toBottomOf="@+id/title"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintTop_toTopOf="@+id/title"
         app:srcCompat="@drawable/ic_search" />
 
     <ImageView


### PR DESCRIPTION
## :scroll: Description
The coloring of the status bar was not matching toolbar colors. This PR fixes that. 
<img width="237" height="100" alt="Screenshot 2026-03-23 at 1 59 55 PM" src="https://github.com/user-attachments/assets/d13f192e-f85f-44d2-8e8e-045e4349bb78" />
<img width="231" height="103" alt="Screenshot 2026-03-23 at 1 59 36 PM" src="https://github.com/user-attachments/assets/8fe756e3-2c69-4843-9ec5-88ead895267a" />
<img width="230" height="141" alt="Screenshot 2026-03-23 at 1 59 24 PM" src="https://github.com/user-attachments/assets/61411eac-f4d4-4643-884b-64416e750570" />

