### PR TITLE
Fix crash in search

### DIFF
--- a/app/src/androidTest/java/journal/gratitude/com/gratitudejournal/fakes/FakeEntryRepository.kt
+++ b/app/src/androidTest/java/journal/gratitude/com/gratitudejournal/fakes/FakeEntryRepository.kt
@@ -2,7 +2,11 @@ package journal.gratitude.com.gratitudejournal.fakes
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
 import androidx.paging.PagingData
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
 import journal.gratitude.com.gratitudejournal.model.Entry
 import journal.gratitude.com.gratitudejournal.repository.EntryRepository
 import kotlinx.coroutines.flow.Flow
@@ -52,19 +56,30 @@ class FakeEntryRepository @Inject constructor() : EntryRepository {
     }
 
     override fun searchEntries(query: String): Flow<PagingData<Entry>> {
-        val list = mutableListOf<Entry>()
-        entriesDatabase.forEach { (_, entry) -> list.add(entry) }
-
-        return if (query == "query with no result") {
-            flow {
-                emit(PagingData.from(emptyList<Entry>()))
-            }
+        val results = if (query == "query with no result") {
+            emptyList()
         } else {
-            val results = listOf(Entry(LocalDate.now(), "Today's content"), Entry(LocalDate.of(2019, 11, 29), "Happy birthday, Alison!"))
-            flow {
-                emit(PagingData.from(results))
-            }
+            listOf(
+                Entry(LocalDate.now(), "Today's content"),
+                Entry(LocalDate.of(2019, 11, 29), "Happy birthday, Alison!")
+            )
         }
+
+        return Pager(
+            config = PagingConfig(pageSize = results.size.coerceAtLeast(1))
+        ) {
+            object : PagingSource<Int, Entry>() {
+                override fun getRefreshKey(state: PagingState<Int, Entry>): Int? = null
+
+                override suspend fun load(params: LoadParams<Int>): LoadResult<Int, Entry> {
+                    return LoadResult.Page(
+                        data = results,
+                        prevKey = null,
+                        nextKey = null
+                    )
+                }
+            }
+        }.flow
     }
 
 }

--- a/app/src/androidTest/java/journal/gratitude/com/gratitudejournal/ui/EntryFragmentInstrumentedTest.kt
+++ b/app/src/androidTest/java/journal/gratitude/com/gratitudejournal/ui/EntryFragmentInstrumentedTest.kt
@@ -1,15 +1,24 @@
 package journal.gratitude.com.gratitudejournal.ui
 
+import android.app.Activity
+import android.app.Instrumentation
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.view.KeyEvent
+import android.view.View
+import android.widget.EditText
+import android.widget.TextView
 import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.UiController
+import androidx.test.espresso.ViewAction
 import androidx.test.espresso.action.ViewActions.*
 import androidx.test.espresso.assertion.ViewAssertions
 import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.intent.Intents.intended
+import androidx.test.espresso.intent.Intents.intending
 import androidx.test.espresso.intent.rule.IntentsRule
 import androidx.test.espresso.intent.matcher.IntentMatchers
 import androidx.test.espresso.matcher.RootMatchers.isDialog
@@ -23,22 +32,24 @@ import dagger.hilt.android.testing.HiltAndroidTest
 import journal.gratitude.com.gratitudejournal.R
 import journal.gratitude.com.gratitudejournal.model.Entry
 import journal.gratitude.com.gratitudejournal.repository.EntryRepository
-import journal.gratitude.com.gratitudejournal.testUtils.getText
-import journal.gratitude.com.gratitudejournal.testUtils.isEditTextValueEqualTo
-import journal.gratitude.com.gratitudejournal.testUtils.saveEntryBlocking
-import journal.gratitude.com.gratitudejournal.testUtils.waitFor
 import journal.gratitude.com.gratitudejournal.ui.entry.EntryFragment
 import org.hamcrest.CoreMatchers.allOf
+import org.hamcrest.CoreMatchers.anyOf
 import org.hamcrest.CoreMatchers.not
+import org.hamcrest.Description
+import org.hamcrest.Matcher
+import org.hamcrest.TypeSafeMatcher
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.threeten.bp.LocalDate
 import javax.inject.Inject
-import journal.gratitude.com.gratitudejournal.testUtils.launchFragmentInHiltContainer
+import kotlinx.coroutines.runBlocking
+import androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom
 import junit.framework.TestCase.assertEquals
 import journal.gratitude.com.gratitudejournal.ui.entry.EntryArgs
+import journal.gratitude.com.gratitudejournal.testUtils.launchFragmentInHiltContainer
 
 @HiltAndroidTest
 @RunWith(AndroidJUnit4::class)
@@ -173,6 +184,21 @@ class EntryFragmentInstrumentedTest {
         val date = LocalDate.of(2019, 3, 22)
 
         val args = EntryArgs(date.toString(), true, 4, "quote", "hint", emptyList())
+        val marketUri = Uri.parse("market://details?id=journal.gratitude.com.gratitudejournal")
+        val webUri = Uri.parse("https://play.google.com/store/apps/details?id=journal.gratitude.com.gratitudejournal")
+
+        intending(
+            anyOf(
+                allOf(
+                    IntentMatchers.hasAction(Intent.ACTION_VIEW),
+                    IntentMatchers.hasData(marketUri)
+                ),
+                allOf(
+                    IntentMatchers.hasAction(Intent.ACTION_VIEW),
+                    IntentMatchers.hasData(webUri)
+                )
+            )
+        ).respondWith(Instrumentation.ActivityResult(Activity.RESULT_OK, Intent()))
 
         launchFragmentInHiltContainer<EntryFragment>(
             themeResId = R.style.Base_AppTheme,
@@ -186,13 +212,19 @@ class EntryFragmentInstrumentedTest {
 
         onView(withId(R.id.save_button)).perform(click())
 
+        onView(withText("Share your achievement")).inRoot(isDialog()).check(matches(isDisplayed()))
         onView(withId(R.id.rate_presently)).perform(click())
 
-        val uri = Uri.parse("market://details?id=journal.gratitude.com.gratitudejournal")
-        androidx.test.espresso.intent.Intents.intended(
-            allOf(
-                IntentMatchers.hasAction(Intent.ACTION_VIEW),
-                IntentMatchers.hasData(uri)
+        intended(
+            anyOf(
+                allOf(
+                    IntentMatchers.hasAction(Intent.ACTION_VIEW),
+                    IntentMatchers.hasData(marketUri)
+                ),
+                allOf(
+                    IntentMatchers.hasAction(Intent.ACTION_VIEW),
+                    IntentMatchers.hasData(webUri)
+                )
             )
         )
     }
@@ -315,7 +347,6 @@ class EntryFragmentInstrumentedTest {
         }
 
         //dialog is displayed
-        onView(isRoot()).perform(waitFor(250))
         onView(withText(R.string.are_you_sure)).inRoot(isDialog()).check(matches(isDisplayed()))
 
         //cancel is pressed
@@ -328,7 +359,7 @@ class EntryFragmentInstrumentedTest {
         }
 
         //continue clicked
-        onView(isRoot()).perform(waitFor(250))
+        onView(withText(R.string.are_you_sure)).inRoot(isDialog()).check(matches(isDisplayed()))
         onView(withId(android.R.id.button1)).inRoot(isDialog()).perform(click())
         onView(withText(R.string.are_you_sure)).check(ViewAssertions.doesNotExist())
     }
@@ -351,4 +382,55 @@ class EntryFragmentInstrumentedTest {
         onView(withText(R.string.are_you_sure)).check(ViewAssertions.doesNotExist())
     }
 
+}
+
+private fun EntryRepository.saveEntryBlocking(entry: Entry) = runBlocking {
+    addEntry(entry)
+}
+
+private fun getText(matcher: Matcher<View>): String {
+    val stringHolder = arrayOf<String?>(null)
+    onView(matcher).perform(object : ViewAction {
+        override fun getConstraints(): Matcher<View> = isAssignableFrom(TextView::class.java)
+
+        override fun getDescription(): String = "getting text from a TextView"
+
+        override fun perform(uiController: UiController, view: View) {
+            stringHolder[0] = (view as TextView).text.toString()
+        }
+    })
+    return stringHolder[0] ?: ""
+}
+
+private fun isEditTextValueEqualTo(content: String): Matcher<View> {
+    return object : TypeSafeMatcher<View>() {
+        override fun describeTo(description: Description) {
+            description.appendText("Match Edit Text Value with View ID Value : :  $content")
+        }
+
+        override fun matchesSafely(view: View?): Boolean {
+            if (view !is TextView && view !is EditText) {
+                return false
+            }
+            val text = if (view is TextView) {
+                view.text.toString()
+            } else {
+                (view as EditText).text.toString()
+            }
+
+            return text.equals(content, ignoreCase = true)
+        }
+    }
+}
+
+private fun waitFor(delay: Long): ViewAction {
+    return object : ViewAction {
+        override fun getConstraints(): Matcher<View> = isRoot()
+
+        override fun getDescription(): String = "wait for ${delay}milliseconds"
+
+        override fun perform(uiController: UiController, view: View) {
+            uiController.loopMainThreadForAtLeast(delay)
+        }
+    }
 }

--- a/app/src/main/java/journal/gratitude/com/gratitudejournal/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/journal/gratitude/com/gratitudejournal/ui/search/SearchViewModel.kt
@@ -3,19 +3,19 @@ package journal.gratitude.com.gratitudejournal.ui.search
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingData
+import androidx.paging.cachedIn
 import dagger.hilt.android.lifecycle.HiltViewModel
 import journal.gratitude.com.gratitudejournal.model.Entry
 import journal.gratitude.com.gratitudejournal.repository.EntryRepository
-import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.transformLatest
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
@@ -24,50 +24,32 @@ class SearchViewModel @Inject constructor(private val repository: EntryRepositor
     private val _uiState = MutableStateFlow(SearchUiState())
     val uiState: StateFlow<SearchUiState> = _uiState.asStateFlow()
 
-    private val _searchResults = MutableStateFlow(PagingData.empty<Entry>())
-    val searchResults: StateFlow<PagingData<Entry>> = _searchResults.asStateFlow()
+    private val searchRequest = MutableStateFlow(SearchRequest())
 
-    private val _searchRequests = MutableSharedFlow<SearchRequest>(
-        extraBufferCapacity = 1,
-        onBufferOverflow = BufferOverflow.DROP_OLDEST
-    )
-    private val searchRequests = _searchRequests.asSharedFlow()
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val searchResults: Flow<PagingData<Entry>> = searchRequest
+        .transformLatest { request ->
+            if (request.debounce) {
+                delay(300)
+            }
 
-    init {
-        observeSearchRequests()
-    }
-
-    private fun observeSearchRequests() {
-        viewModelScope.launch {
-            searchRequests.collectLatest { request ->
-                if (request.debounce) {
-                    delay(300)
-                }
-                performSearch(request.query)
+            val trimmedQuery = request.query.trim()
+            if (trimmedQuery.isEmpty()) {
+                emit(PagingData.empty())
+            } else {
+                emitAll(repository.searchEntries(trimmedQuery))
             }
         }
-    }
-
-    private suspend fun performSearch(query: String) {
-        val trimmedQuery = query.trim()
-        if (trimmedQuery.isEmpty()) {
-            _searchResults.value = PagingData.empty()
-            return
-        }
-
-        repository.searchEntries(trimmedQuery).collectLatest { pagingData ->
-            _searchResults.value = pagingData
-        }
-    }
+        .cachedIn(viewModelScope)
 
     fun onSearchQueryChanged(queryString: String) {
         _uiState.update { it.copy(query = queryString) }
-        _searchRequests.tryEmit(SearchRequest(query = queryString, debounce = true))
+        searchRequest.value = SearchRequest(query = queryString, debounce = true)
     }
 
     fun onSearchTriggered(queryString: String) {
         _uiState.update { it.copy(query = queryString) }
-        _searchRequests.tryEmit(SearchRequest(query = queryString, debounce = false))
+        searchRequest.value = SearchRequest(query = queryString, debounce = false)
     }
 }
 
@@ -76,6 +58,6 @@ data class SearchUiState(
 )
 
 private data class SearchRequest(
-    val query: String,
-    val debounce: Boolean
+    val query: String = "",
+    val debounce: Boolean = false
 )

--- a/app/src/test/java/journal/gratitude/com/gratitudejournal/ui/search/SearchViewModelTest.kt
+++ b/app/src/test/java/journal/gratitude/com/gratitudejournal/ui/search/SearchViewModelTest.kt
@@ -4,6 +4,10 @@ import androidx.paging.PagingData
 import com.google.common.truth.Truth.assertThat
 import com.nhaarman.mockitokotlin2.*
 import journal.gratitude.com.gratitudejournal.testUtils.MainDispatcherRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.advanceTimeBy
@@ -13,6 +17,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class SearchViewModelTest {
 
     private val repository = mock<EntryRepository>()
@@ -37,6 +42,7 @@ class SearchViewModelTest {
 
     @Test
     fun searchResults_calls_repository_afterDebounce() = runTest() {
+        val collector = async { viewModel.searchResults.drop(1).first() }
         advanceUntilIdle()
 
         viewModel.onSearchQueryChanged("Yo yo yo")
@@ -44,27 +50,42 @@ class SearchViewModelTest {
         verify(repository, never()).searchEntries(any())
 
         advanceTimeBy(1)
-        advanceUntilIdle()
+        collector.await()
         verify(repository, times(1)).searchEntries("Yo yo yo")
     }
 
     @Test
     fun searchResults_doesNotSearchBlankStrings() = runTest() {
+        val collector = async { viewModel.searchResults.drop(1).first() }
         advanceUntilIdle()
 
         viewModel.onSearchQueryChanged("")
         advanceTimeBy(300)
-        advanceUntilIdle()
+        collector.await()
 
         verify(repository, never()).searchEntries(any())
     }
 
     @Test
     fun onSearchTriggered_searchesImmediately() = runTest() {
+        val collector = async { viewModel.searchResults.drop(1).first() }
         advanceUntilIdle()
 
         viewModel.onSearchTriggered("Yo yo yo")
+        collector.await()
+
+        verify(repository, times(1)).searchEntries("Yo yo yo")
+    }
+
+    @Test
+    fun searchResults_multipleCollectors_shareSingleSearch() = runTest {
+        val firstCollector = async { viewModel.searchResults.drop(1).first() }
+        val secondCollector = async { viewModel.searchResults.drop(1).first() }
         advanceUntilIdle()
+
+        viewModel.onSearchTriggered("Yo yo yo")
+        firstCollector.await()
+        secondCollector.await()
 
         verify(repository, times(1)).searchEntries("Yo yo yo")
     }


### PR DESCRIPTION
## :scroll: Description
Fixes a production Paging crash in search. Users could trigger it by searching, opening a result, then navigating back to search, which caused the same PagingData instance to be collected twice.

The fix changes search to expose a cached paging Flow with cachedIn(viewModelScope) instead of storing PagingData in StateFlow. Tests were updated and a regression test was added for multiple collectors.